### PR TITLE
build: WSL clang-cl + xwin cross-compile check loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@
 Testing
 cmake-*
 build
+build-wsl
 .worktrees

--- a/cmake/toolchains/clang-cl-win32.cmake
+++ b/cmake/toolchains/clang-cl-win32.cmake
@@ -57,6 +57,16 @@ set(CMAKE_LINKER       "${_lld_link}")
 set(CMAKE_AR           "${_llvm_lib}")
 set(CMAKE_RC_COMPILER  "${_llvm_rc}")
 
+# Neutralize the manifest tool. Homebrew's LLVM ships no llvm-mt, and CMake's
+# find_program(mt) otherwise picks up the Linux magnetic-tape tool /usr/bin/mt,
+# which breaks the post-link step. Manifest embedding is irrelevant to a
+# compile/link check, so point CMAKE_MT at /bin/true: it is a real (found,
+# non-empty) path so find_program won't override it, and it exits 0 -- which
+# CMake's vs_link wrapper reads as "manifest not updated", keeping the linked
+# DLL without an embed step. (An empty value does NOT work: find_program
+# re-searches and re-finds /usr/bin/mt.)
+set(CMAKE_MT "/bin/true" CACHE FILEPATH "manifest tool neutralized for the WSL check loop" FORCE)
+
 # 32-bit MSVC target triple for both languages.
 set(CMAKE_C_COMPILER_TARGET   i686-pc-windows-msvc)
 set(CMAKE_CXX_COMPILER_TARGET i686-pc-windows-msvc)
@@ -74,8 +84,10 @@ set(_xwin_incs
     "/imsvc${XWIN_SPLAT}/sdk/include/shared")
 string(JOIN " " _xwin_incflags ${_xwin_incs})
 
-# -fasm-blocks: parse the MS-style __asm jmp thunks in proxy/ijl15.cpp.
-set(_common_flags "-fms-compatibility -fms-extensions -fasm-blocks ${_xwin_incflags}")
+# -fms-extensions already enables the MS-style __asm jmp thunks in
+# proxy/ijl15.cpp (verified: clang-cl compiles `__asm jmp dword ptr[p]` under
+# -fms-extensions with no extra flag; -fasm-blocks is an unknown arg in clang-cl).
+set(_common_flags "-fms-compatibility -fms-extensions ${_xwin_incflags}")
 set(CMAKE_C_FLAGS_INIT   "${_common_flags}")
 set(CMAKE_CXX_FLAGS_INIT "${_common_flags}")
 

--- a/cmake/toolchains/clang-cl-win32.cmake
+++ b/cmake/toolchains/clang-cl-win32.cmake
@@ -1,0 +1,98 @@
+# Cross-compile the Win32 MSVC-ABI edit DLLs in WSL with clang-cl + lld-link,
+# using an xwin-produced splat of the MSVC CRT + Windows SDK. Dev-only check
+# loop; CI on windows-2025 remains authoritative. See
+# docs/tasks/wsl-cross-compile/design.md.
+#
+# Tool locations come from two keg-only Homebrew formulae and therefore live in
+# DIFFERENT directories:
+#   LLVM_BIN -> clang-cl, llvm-lib, llvm-rc   ($(brew --prefix llvm)/bin)
+#   LLD_BIN  -> lld-link                       ($(brew --prefix lld)/bin)
+# scripts/wsl-build.sh resolves both and passes them as -D. When invoked
+# directly without those vars, we fall back to bare names on PATH.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+
+# --- locate the xwin splat (override with -DXWIN_SPLAT=... or env XWIN_SPLAT) ---
+if(NOT XWIN_SPLAT)
+    if(DEFINED ENV{XWIN_SPLAT})
+        set(XWIN_SPLAT "$ENV{XWIN_SPLAT}")
+    else()
+        set(XWIN_SPLAT "$ENV{HOME}/.xwin-splat")
+    endif()
+endif()
+if(NOT EXISTS "${XWIN_SPLAT}/crt/include")
+    message(FATAL_ERROR
+        "xwin splat not found at '${XWIN_SPLAT}'. "
+        "Run scripts/wsl-build.sh (it checks) or see "
+        "docs/tasks/wsl-cross-compile/README.md.")
+endif()
+
+# --- locate the LLVM + LLD tools (override with -DLLVM_BIN/-DLLD_BIN or env) ---
+if(NOT LLVM_BIN AND DEFINED ENV{LLVM_BIN})
+    set(LLVM_BIN "$ENV{LLVM_BIN}")
+endif()
+if(NOT LLD_BIN AND DEFINED ENV{LLD_BIN})
+    set(LLD_BIN "$ENV{LLD_BIN}")
+endif()
+
+if(LLVM_BIN)
+    set(_clang_cl  "${LLVM_BIN}/clang-cl")
+    set(_llvm_lib  "${LLVM_BIN}/llvm-lib")
+    set(_llvm_rc   "${LLVM_BIN}/llvm-rc")
+else()
+    set(_clang_cl  clang-cl)
+    set(_llvm_lib  llvm-lib)
+    set(_llvm_rc   llvm-rc)
+endif()
+if(LLD_BIN)
+    set(_lld_link "${LLD_BIN}/lld-link")
+else()
+    set(_lld_link lld-link)
+endif()
+
+set(CMAKE_C_COMPILER   "${_clang_cl}")
+set(CMAKE_CXX_COMPILER "${_clang_cl}")
+set(CMAKE_LINKER       "${_lld_link}")
+set(CMAKE_AR           "${_llvm_lib}")
+set(CMAKE_RC_COMPILER  "${_llvm_rc}")
+
+# 32-bit MSVC target triple for both languages.
+set(CMAKE_C_COMPILER_TARGET   i686-pc-windows-msvc)
+set(CMAKE_CXX_COMPILER_TARGET i686-pc-windows-msvc)
+
+# Compile-only the toolchain probe so configure doesn't depend on a linkable
+# entry point. Real link validation happens when we build the DLLs.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# MSVC-system include dirs from the splat. /imsvc keeps them on the system path
+# (no -Wnonportable-include-path noise from the SDK's own headers).
+set(_xwin_incs
+    "/imsvc${XWIN_SPLAT}/crt/include"
+    "/imsvc${XWIN_SPLAT}/sdk/include/ucrt"
+    "/imsvc${XWIN_SPLAT}/sdk/include/um"
+    "/imsvc${XWIN_SPLAT}/sdk/include/shared")
+string(JOIN " " _xwin_incflags ${_xwin_incs})
+
+# -fasm-blocks: parse the MS-style __asm jmp thunks in proxy/ijl15.cpp.
+set(_common_flags "-fms-compatibility -fms-extensions -fasm-blocks ${_xwin_incflags}")
+set(CMAKE_C_FLAGS_INIT   "${_common_flags}")
+set(CMAKE_CXX_FLAGS_INIT "${_common_flags}")
+
+# Library search paths for lld-link.
+set(_xwin_libs
+    "/libpath:${XWIN_SPLAT}/crt/lib/x86"
+    "/libpath:${XWIN_SPLAT}/sdk/lib/um/x86"
+    "/libpath:${XWIN_SPLAT}/sdk/lib/ucrt/x86")
+string(JOIN " " _xwin_libflags ${_xwin_libs})
+set(_link_init "/machine:x86 ${_xwin_libflags}")
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${_link_init}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_link_init}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_link_init}")
+
+# Only search the splat for headers/libs; never the (empty) host Windows roots.
+set(CMAKE_FIND_ROOT_PATH "${XWIN_SPLAT}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/cmake/toolchains/clang-cl-win32.cmake
+++ b/cmake/toolchains/clang-cl-win32.cmake
@@ -87,9 +87,18 @@ string(JOIN " " _xwin_incflags ${_xwin_incs})
 # -fms-extensions already enables the MS-style __asm jmp thunks in
 # proxy/ijl15.cpp (verified: clang-cl compiles `__asm jmp dword ptr[p]` under
 # -fms-extensions with no extra flag; -fasm-blocks is an unknown arg in clang-cl).
+#
+# /FI wsl-eh-forceinclude.h: MSVC's frontend force-injects the internal EH
+# declarations (_CxxThrowException / _ThrowInfo) into every C++ TU; clang-cl does
+# not, so bypass/client_exception.cpp would not compile. This shim supplies just
+# those two symbols for the cross-build (CI never sees it). See the header.
+set(_force_inc "/FI${CMAKE_CURRENT_LIST_DIR}/wsl-eh-forceinclude.h")
 set(_common_flags "-fms-compatibility -fms-extensions ${_xwin_incflags}")
+# The EH shim is C++-only (extern "C" is a syntax error in C, and CMake's C
+# compiler probe would choke). Force-include it for CXX only; the project has no
+# C TUs anyway.
 set(CMAKE_C_FLAGS_INIT   "${_common_flags}")
-set(CMAKE_CXX_FLAGS_INIT "${_common_flags}")
+set(CMAKE_CXX_FLAGS_INIT "${_common_flags} ${_force_inc}")
 
 # Library search paths for lld-link.
 set(_xwin_libs

--- a/cmake/toolchains/wsl-eh-forceinclude.h
+++ b/cmake/toolchains/wsl-eh-forceinclude.h
@@ -1,0 +1,34 @@
+// WSL cross-build ONLY -- force-included into every TU via /FI by
+// cmake/toolchains/clang-cl-win32.cmake. Never referenced by the MSVC/CI build.
+//
+// Why this exists:
+//   bypass/client_exception.cpp calls _CxxThrowException and casts client RTTI
+//   tables to _ThrowInfo*, relying on those names being visible "through
+//   <windows.h>" (see the comment in that file). On MSVC that holds because the
+//   c1xx frontend preprocesses <ehdata_forceinclude.h> and force-injects it into
+//   every C++ TU. clang-cl performs no such injection, and that header is not
+//   directly includable (it carries MSVC pre-pass tokens like `prepifdef`).
+//
+//   So for the clang-cl cross-build we declare exactly the two symbols the
+//   faithful-RTTI code needs, with the MSVC ABI signature copied verbatim from
+//   ehdata_forceinclude.h (extern "C", __declspec(noreturn), __stdcall). The
+//   client's per-version _ThrowInfo tables are referenced only as pointers, so an
+//   incomplete type is sufficient and avoids duplicating MSVC's struct layout.
+//
+//   This file is invisible to MSVC/CI, so it cannot trigger the C2733 (mismatched
+//   prototype) / C2371 (redefinition) clashes that a local declaration inside the
+//   .cpp would cause there.
+#pragma once
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#error "wsl-eh-forceinclude.h is for the clang-cl cross-build only; never compile it with MSVC."
+#endif
+
+// C++-only (extern "C" is a syntax error in C). The toolchain force-includes
+// this for CXX TUs only; the guard is belt-and-suspenders.
+#ifdef __cplusplus
+struct _ThrowInfo;
+
+extern "C" __declspec(noreturn) void __stdcall
+_CxxThrowException(void* pExceptionObject, _ThrowInfo* pThrowInfo);
+#endif

--- a/cmake/toolchains/wsl-eh-forceinclude.h
+++ b/cmake/toolchains/wsl-eh-forceinclude.h
@@ -29,6 +29,5 @@
 #ifdef __cplusplus
 struct _ThrowInfo;
 
-extern "C" __declspec(noreturn) void __stdcall
-_CxxThrowException(void* pExceptionObject, _ThrowInfo* pThrowInfo);
+extern "C" __declspec(noreturn) void __stdcall _CxxThrowException(void* pExceptionObject, _ThrowInfo* pThrowInfo);
 #endif

--- a/docs/tasks/wsl-cross-compile/README.md
+++ b/docs/tasks/wsl-cross-compile/README.md
@@ -1,0 +1,82 @@
+# WSL cross-compile check loop
+
+Compile + link the Win32 edit DLLs inside WSL with `clang-cl` + `lld-link`, to
+catch compile/link errors without a Windows round-trip.
+
+**This is a dev-only check, not the authoritative build.** CI on `windows-2025`
+(`.github/workflows/_build.yml`) owns the shipping artifacts. A successful WSL
+build means "it compiles and links"; it is *not* a guarantee of byte/ABI parity
+with the MSVC build, and the produced DLLs are not intended to be injected into
+the client. To actually run a DLL, build on Windows.
+
+## One-time setup
+
+1. **Toolchain** (Homebrew, no sudo). `lld` is a *separate* formula from `llvm`
+   (Homebrew's `llvm` ships `lldb`, not `lld`), and the two install to different
+   keg prefixes — both are needed:
+   ```bash
+   brew install llvm lld ninja
+   ```
+2. **xwin + the MSVC/SDK splat** (~1 GB). The flags matter:
+   - `--include-atl` — `common/pch.h` pulls in `<atlstr.h>` (ATL `CString`).
+   - `splat --include-debug-libs` — a Debug build links the debug CRT
+     (`msvcrtd.lib`, `comsuppwd.lib`, …).
+   - `--copy` — in WSL the cache (`/tmp`) and output (`$HOME`) are usually on
+     different filesystems; the default *move* fails with a cross-device error.
+   ```bash
+   brew install xwin
+   xwin --accept-license --arch x86 --include-atl --cache-dir /tmp/.xwin-cache \
+        splat --output "$HOME/.xwin-splat" --copy --include-debug-libs
+   ```
+
+## Usage
+
+```bash
+# defaults to GMS 83 1, all edit DLLs + proxy
+./scripts/wsl-build.sh
+
+# specific region/version (three separate tokens)
+./scripts/wsl-build.sh GMS 87 1
+
+# single target (fast iteration)
+./scripts/wsl-build.sh GMS 83 1 skip-logo
+```
+
+Build output lands in `build-wsl/` (gitignored). The script resolves the LLVM and
+LLD kegs automatically and self-heals the one SDK lib case-alias xwin omits
+(`Ws2_32.lib`).
+
+> Pass region/major/minor as **three separate arguments**, not one quoted string.
+> Under `zsh`, `cfg="GMS 87 1"; wsl-build.sh $cfg` does NOT word-split and passes
+> the whole string as the region. Use `wsl-build.sh GMS 87 1` or a bash array.
+
+## Overrides
+
+- `XWIN_SPLAT` — splat location (default `~/.xwin-splat`).
+- `LLVM_BIN`  — clang-cl/llvm-lib/llvm-rc dir (default `$(brew --prefix llvm)/bin`).
+- `LLD_BIN`   — lld-link dir (default `$(brew --prefix lld)/bin`).
+
+## Supported configs
+
+GMS 83.1, 84.1, 87.1, 95.1, 111.1; JMS 185.1 — matching the CI matrix. All six
+verified to compile + link (11 DLLs each: 10 edit DLLs + `proxy/ijl15.dll`).
+
+## How it works (and the WSL-only adaptations)
+
+`cmake/toolchains/clang-cl-win32.cmake` targets `i686-pc-windows-msvc` with the
+xwin splat on the include/lib search paths. Three differences from a stock MSVC
+build, all confined to the toolchain (no client-source changes):
+
+- **Manifest tool** — Homebrew's LLVM has no `llvm-mt`, and CMake's
+  `find_program(mt)` otherwise grabs the Linux tape tool `/usr/bin/mt`. The
+  toolchain sets `CMAKE_MT=/bin/true` to neutralize the (irrelevant) manifest
+  embed step.
+- **MS inline asm** — `proxy/ijl15.cpp`'s `__asm jmp` thunks compile under
+  `-fms-extensions` (no `-fasm-blocks`, which clang-cl rejects as unknown).
+- **EH force-include** — MSVC's frontend force-injects
+  `<ehdata_forceinclude.h>` (declaring `_CxxThrowException` / `_ThrowInfo`) into
+  every C++ TU; clang-cl does not. `cmake/toolchains/wsl-eh-forceinclude.h`
+  supplies just those two symbols via `/FI` (CXX-only) so
+  `bypass/client_exception.cpp` compiles. CI never sees this shim.
+
+See `docs/tasks/wsl-cross-compile/design.md` and `plan.md` for the full rationale.

--- a/docs/tasks/wsl-cross-compile/design.md
+++ b/docs/tasks/wsl-cross-compile/design.md
@@ -1,0 +1,138 @@
+# WSL clang-cl Cross-Compile Check Loop — Design
+
+**Date:** 2026-06-12
+**Status:** Design (pending review)
+**Author:** brainstormed with Claude
+
+## Problem
+
+The edit DLLs in this repo are **Win32, MSVC-ABI** shared libraries injected into
+the MapleStory client. The authoritative build runs on GitHub Actions
+(`windows-2025` + MSVC, see `.github/workflows/_build.yml`). Claude works in WSL,
+which has no MSVC toolchain, so every code change Claude makes must be handed to
+the user via a git branch and built on Windows before any compile error surfaces.
+That round-trip is the friction this design removes.
+
+## Goal
+
+Let Claude **configure, compile, and link** the edit DLLs entirely inside WSL, to
+catch compile-time and link-time errors before the branch handoff. A successful
+`compile + link` is the bar.
+
+### Non-goals
+
+- **Not** byte-for-byte / ABI-identical output vs the VS build. CI on
+  `windows-2025` remains the single authoritative artifact source. (Decision:
+  "compile-check loop only".)
+- **Not** replacing the local Windows build the user uses to *run* DLLs in the
+  live client. Injecting and running still requires Windows + the game.
+- **Not** changing CI. `.github/workflows/*` is untouched.
+
+The git-branch handoff for *running* a DLL in the client remains. Only the
+*compile/link feedback* moves into WSL.
+
+## Approach
+
+**`clang-cl` + `lld-link` targeting `i686-pc-windows-msvc`, with the MSVC CRT and
+Windows SDK supplied by [`xwin`](https://github.com/Jake-Shadle/xwin); Ninja
+generator.**
+
+Why this and not the alternatives:
+
+- **clang-cl over MinGW (`i686-w64-mingw32`)** — clang-cl targets the *MSVC ABI*
+  (name mangling, exception model, struct layout, vtable shape). MinGW uses a
+  different CRT and ABI; given this project's whole point is faithful client RE
+  (RTTI exception dispatch, exact struct layouts), a MinGW build could compile
+  yet diverge silently from what ships. clang-cl keeps the ABI honest.
+- **clang-cl is a `cl.exe`-compatible driver** — CMake's MSVC detection and flag
+  generation Just Work; `#pragma comment(lib, ...)`, SEH (`__try/__except`), and
+  `/imsvc` are all supported.
+- **`lld-link` consumes MSVC COFF** — it links the existing vendored
+  `common/detours.lib` (confirmed `!<arch>` i386 COFF, machine `0x014c`) and the
+  Win32 SDK import libs directly. No need to rebuild Detours.
+- **Ninja generator** — avoids the `Visual Studio 18 2026` generator + CMake ≥4.2
+  coupling that CI carries. Local cmake is 4.3.2; Ninja has no such constraint.
+- **xwin** — downloads the MSVC CRT + Windows SDK (headers + Win32 libs) from
+  Microsoft's published redistributable manifests into a local "splat" directory,
+  and normalizes the header-case issues that otherwise break `#include <Windows.h>`
+  on a case-sensitive filesystem. This is precisely the problem xwin exists to
+  solve.
+
+## Components
+
+1. **Host toolchain (one-time install).**
+   `clang` (provides `clang-cl` + `lld-link`), `ninja`, and `xwin`. `cmake`
+   (4.3.2) is already present via Homebrew. Install path documented in the
+   dev-doc; the install itself is a manual prerequisite step, not scripted into
+   the build (it needs the user's package manager / sudo).
+
+2. **xwin SDK splat.**
+   `xwin splat --output <dir>` produces `crt/{include,lib}` and
+   `sdk/{include,lib}` with the Win32 (`x86`) libraries. Stored **outside the git
+   tree** (default `~/.xwin-splat`, overridable via env var) — it is ~1 GB and
+   license-gated (xwin records EULA acceptance). Never committed.
+
+3. **CMake toolchain file** — `cmake/toolchains/clang-cl-win32.cmake`:
+   - `CMAKE_SYSTEM_NAME=Windows`, `CMAKE_SYSTEM_PROCESSOR=x86`
+   - `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER=clang-cl`, `CMAKE_LINKER=lld-link`
+   - `--target=i686-pc-windows-msvc`
+   - `/imsvc` include flags pointing at `crt/include` and
+     `sdk/include/{um,shared,ucrt}` from the splat
+   - linker `/LIBPATH:` entries for `crt/lib/x86` and `sdk/lib/{um,ucrt}/x86`
+   - `-fasm-blocks` so the MS-style `__asm` thunks in `proxy/ijl15.cpp` parse
+   - splat location read from an env var (e.g. `XWIN_SPLAT`) with a sensible
+     default, so the file isn't machine-specific
+
+4. **Driver script** — `scripts/wsl-build.sh`:
+   - Usage: `scripts/wsl-build.sh [REGION] [MAJOR] [MINOR] [TARGET]`,
+     defaulting to `GMS 83 1` and the all-DLLs default target.
+   - Runs `cmake -G Ninja -B build-wsl --toolchain
+     cmake/toolchains/clang-cl-win32.cmake -DBUILD_REGION=… -DBUILD_MAJOR_VERSION=…
+     -DBUILD_MINOR_VERSION=…` then `cmake --build build-wsl`.
+   - `build-wsl/` is gitignored (the existing `build` / `cmake-*` ignore rules
+     cover a chosen dir name; confirm the name is ignored).
+   - Fails loudly if `clang-cl`, `lld-link`, `ninja`, or the splat dir are absent,
+     pointing at the dev-doc.
+
+5. **Dev-doc** — `docs/tasks/wsl-cross-compile/README.md` (or a section in the
+   existing docs): how to install the toolchain, run xwin once, and invoke the
+   driver. States plainly that this is a dev-only check, not the authoritative
+   build.
+
+## Validation / success criteria
+
+A success ladder, each step gating the next:
+
+1. **MVP proof:** `scripts/wsl-build.sh GMS 83 1 skip-logo` configures and **links
+   `skip-logo` to a `.dll`** in WSL with zero errors. (`skip-logo` chosen as the
+   simplest edit DLL.)
+2. **Full default target:** `scripts/wsl-build.sh GMS 83 1` builds every edit DLL
+   + `proxy` for GMS 83.1.
+3. **Stretch — matrix coverage:** the other five CI configs (GMS 84.1, 87.1, 95.1,
+   111.1; JMS 185.1) configure + build. They differ only by the included
+   memory-map `.cmake` and compile defs, so this should be near-free once (2)
+   works.
+
+Out of scope for validation: byte/ABI equivalence with VS output.
+
+## Tracked risks (and fallbacks)
+
+| Risk | Detail | Fallback |
+|---|---|---|
+| **Header case-sensitivity** | `#include <Windows.h>` etc. vs lowercase files on a case-sensitive FS | xwin normalizes casing during splat; this is its core purpose. If gaps remain, add targeted symlinks. |
+| **`comsuppw.lib`** | MSVC VCTools lib for `_bstr_t`/`_com_ptr_t`/`comdef`, used widely in `common/*.h`. Must be present to link. | Confirm xwin's CRT splat includes it. If absent, source the lib or (worst case) the affected DLLs stay compile-only. |
+| **`__asm` thunks ×6** | `proxy/ijl15.cpp` uses MS inline asm (`jmp dword ptr[mem]`) | `-fasm-blocks` should handle these trivial jumps. If clang's MS-asm parser balks, `proxy` is the one DLL that may stay compile-only; flag before any source edit. |
+| **SEH `__try/__except`** | `common/memedit.cpp` | clang-cl supports x86 SEH; low risk, listed for completeness. |
+| **PCH `REUSE_FROM`** | `add_edit_dll` reuses `common_lib`'s PCH | All TUs here are clang-cl, so the shared PCH is self-consistent. The VS-produced PCH is irrelevant (separate `build-wsl/` dir). |
+
+If a risk turns into a wall, the degradation is graceful and pre-agreed:
+**fall back to compile-only** (objects, no link) for the affected target and report
+it, rather than silently dropping coverage.
+
+## What this explicitly does not touch
+
+- `.github/workflows/*` — CI stays on `windows-2025` + MSVC, authoritative.
+- Source code — no changes anticipated. The sole candidate is the inline-asm in
+  `proxy/ijl15.cpp`, and only if `-fasm-blocks` is insufficient; any such edit is
+  flagged for approval first.
+- The existing VS / CLion build the user runs — left as-is.

--- a/docs/tasks/wsl-cross-compile/plan.md
+++ b/docs/tasks/wsl-cross-compile/plan.md
@@ -30,33 +30,45 @@ for t in clang-cl lld-link llvm-lib ninja; do printf "%-12s" "$t:"; command -v $
 ```
 Expected: likely all `MISSING` on a fresh WSL (only `cmake` is preinstalled via Homebrew).
 
-- [ ] **Step 2: Install LLVM (provides clang-cl, lld-link, llvm-lib, llvm-rc) and ninja via Homebrew**
+- [ ] **Step 2: Install LLVM, LLD, and ninja via Homebrew**
 
-Homebrew is already on this machine (`/home/linuxbrew/.linuxbrew`), so no sudo is needed.
+Homebrew is already on this machine (`/home/linuxbrew/.linuxbrew`), so no sudo is
+needed. **NOTE (correction from bring-up):** Homebrew's `llvm` formula ships
+`clang-cl`, `llvm-lib`, `llvm-rc`, and `lldb` (debugger) but **not** `lld` (the
+linker). `lld-link` comes from the *separate* `lld` formula, and it installs into
+a **different keg** (`$(brew --prefix lld)/bin`, not the llvm bin). Both are needed.
 
 Run:
 ```bash
-brew install llvm ninja
+brew install llvm lld ninja
 ```
-Expected: completes (llvm is ~1.5 GB; may take several minutes).
+Expected: completes (llvm is ~1.5 GB; lld ~8 MB; may take several minutes).
 
-- [ ] **Step 3: Put the LLVM bin dir on PATH and verify the four tools resolve**
+- [ ] **Step 3: Verify the tools resolve across both kegs**
 
-`brew install llvm` is keg-only, so its tools are NOT symlinked into the default
-Homebrew bin. Resolve the prefix and verify:
+Both `llvm` and `lld` are keg-only, so their tools are NOT symlinked into the
+default Homebrew bin. clang-cl/llvm-lib/llvm-rc live under the llvm keg; lld-link
+under the lld keg:
 ```bash
 LLVM_BIN="$(brew --prefix llvm)/bin"
-for t in clang-cl lld-link llvm-lib llvm-rc ninja; do printf "%-12s" "$t:"; "$LLVM_BIN/$t" --version >/dev/null 2>&1 && echo "OK ($LLVM_BIN/$t)" || command -v "$t" || echo MISSING; done
+LLD_BIN="$(brew --prefix lld)/bin"
+for t in clang-cl llvm-lib llvm-rc; do printf "%-12s" "$t:"; [[ -x "$LLVM_BIN/$t" ]] && echo "OK ($LLVM_BIN/$t)" || echo MISSING; done
+printf "%-12s" "lld-link:"; [[ -x "$LLD_BIN/lld-link" ]] && echo "OK ($LLD_BIN/lld-link)" || echo MISSING
+printf "%-12s" "ninja:"; ninja --version >/dev/null 2>&1 && echo OK || echo MISSING
 ```
-Expected: `clang-cl`, `lld-link`, `llvm-lib`, `llvm-rc` resolve under `$(brew --prefix llvm)/bin`; `ninja` resolves on PATH. Record `LLVM_BIN` — the driver script (Task 4) and toolchain file (Task 3) reference these tools by absolute path so a non-interactive shell finds them.
+Expected: every tool prints `OK`. Record both `LLVM_BIN` and `LLD_BIN` — the driver
+script (Task 4) and toolchain file (Task 3) reference these tools by absolute path
+so a non-interactive shell finds them.
 
-- [ ] **Step 4: Capture the LLVM bin path for later tasks**
+- [ ] **Step 4: Capture both bin paths for later tasks**
 
 Run:
 ```bash
 echo "LLVM_BIN=$(brew --prefix llvm)/bin"
+echo "LLD_BIN=$(brew --prefix lld)/bin"
 ```
-Expected: prints e.g. `LLVM_BIN=/home/linuxbrew/.linuxbrew/opt/llvm/bin`. No commit (host setup only).
+Expected: prints e.g. `LLVM_BIN=/home/linuxbrew/.linuxbrew/opt/llvm/bin` and
+`LLD_BIN=/home/linuxbrew/.linuxbrew/opt/lld/bin`. No commit (host setup only).
 
 ---
 
@@ -66,25 +78,29 @@ Expected: prints e.g. `LLVM_BIN=/home/linuxbrew/.linuxbrew/opt/llvm/bin`. No com
 
 - [ ] **Step 1: Install the xwin binary**
 
-Prefer a prebuilt release binary (no Rust toolchain needed). Run:
+**CORRECTION (from bring-up):** xwin has a Homebrew formula (simpler than the
+release tarball), and the current version is **0.9.0**, not 0.6.6. Install via brew:
 ```bash
-XWIN_VER=0.6.6
-cd /tmp
-curl -fsSL "https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VER}/xwin-${XWIN_VER}-x86_64-unknown-linux-musl.tar.gz" -o xwin.tgz
-tar -xzf xwin.tgz
-install -m755 "xwin-${XWIN_VER}-x86_64-unknown-linux-musl/xwin" "$(brew --prefix)/bin/xwin"
+brew install xwin
 xwin --version
 ```
-Expected: prints `xwin 0.6.6` (or the pinned version). If the download 404s, fall back to `cargo install xwin` (requires `brew install rust` first).
+Expected: prints `xwin 0.9.0`. In 0.9.0 the `--arch` filter is a **global** option
+(before the subcommand): `xwin --arch x86 splat ...`.
 
 - [ ] **Step 2: Download + splat the CRT and Windows SDK (Win32/x86 only)**
 
 This accepts the Microsoft redistributable license and writes ~1 GB to `~/.xwin-splat`.
-Run:
+
+**CORRECTION (from bring-up):** xwin *moves* files from its cache to the output by
+default. In this WSL `/tmp` (cache) and `/home` (output) are different filesystems,
+so the move fails with `Invalid cross-device link (EXDEV)`. Use `--copy` to copy
+instead of move. Keep the cache on `/tmp` to reuse any prior download.
 ```bash
-xwin --accept-license --arch x86 splat --output "$HOME/.xwin-splat"
+xwin --accept-license --arch x86 --cache-dir /tmp/.xwin-cache \
+     splat --output "$HOME/.xwin-splat" --copy
 ```
-Expected: completes with a `crt/` and `sdk/` tree under `~/.xwin-splat`. (Downloads are cached under `./.xwin-cache`; delete `/tmp/.xwin-cache` afterward if created.)
+Expected: completes silently with a `crt/` and `sdk/` tree under `~/.xwin-splat`.
+Symlinks are on by default — that is what fixes `#include <Windows.h>` casing.
 
 - [ ] **Step 3: Verify the splat contains the headers and libs this project needs**
 
@@ -112,6 +128,14 @@ ls -la "$S/sdk/lib/um/x86/" | grep -i 'ws2_32\.lib'
 ```
 Expected: a `ws2_32.lib` entry exists (xwin lowercases SDK lib names and/or creates case symlinks by default). Note the actual casing — if only one case exists and it differs from a `#pragma comment(lib, ...)` spelling, that is the case-sensitivity risk materializing; the fallback is a symlink added in Task 4's script. No commit (host setup only).
 
+**FINDING (from bring-up):** The real file is `WS2_32.Lib`; xwin created symlinks
+`ws2_32.lib` and `WS2_32.lib` (636 case symlinks in that dir total), so the
+`#pragma comment(lib, "WS2_32.lib")` spelling resolves. BUT `cmake/CommonLib.cmake`
+references the mixed-case `Ws2_32.lib` (capital W, lowercase `s2_32`), and xwin did
+**not** create that exact permutation. This is the one casing gap; the driver script
+(Task 4) creates the `Ws2_32.lib` symlink idempotently. All other libs
+(`winmm.lib`, `comsuppw.lib`, vendored `detours.lib`) resolve as-is.
+
 ---
 
 ### Task 3: Write the CMake toolchain file
@@ -121,109 +145,36 @@ Expected: a `ws2_32.lib` entry exists (xwin lowercases SDK lib names and/or crea
 
 - [ ] **Step 1: Write the toolchain file**
 
-Create `cmake/toolchains/clang-cl-win32.cmake` with exactly:
-```cmake
-# Cross-compile the Win32 MSVC-ABI edit DLLs in WSL with clang-cl + lld-link,
-# using an xwin-produced splat of the MSVC CRT + Windows SDK. Dev-only check
-# loop; CI on windows-2025 remains authoritative. See
-# docs/tasks/wsl-cross-compile/design.md.
-
-set(CMAKE_SYSTEM_NAME Windows)
-set(CMAKE_SYSTEM_PROCESSOR x86)
-
-# --- locate the xwin splat (override with -DXWIN_SPLAT=... or env XWIN_SPLAT) ---
-if(NOT XWIN_SPLAT)
-    if(DEFINED ENV{XWIN_SPLAT})
-        set(XWIN_SPLAT "$ENV{XWIN_SPLAT}")
-    else()
-        set(XWIN_SPLAT "$ENV{HOME}/.xwin-splat")
-    endif()
-endif()
-if(NOT EXISTS "${XWIN_SPLAT}/crt/include")
-    message(FATAL_ERROR
-        "xwin splat not found at '${XWIN_SPLAT}'. "
-        "Run scripts/wsl-build.sh (it checks/installs) or see "
-        "docs/tasks/wsl-cross-compile/README.md.")
-endif()
-
-# --- locate the LLVM tools (override with -DLLVM_BIN=... or env LLVM_BIN) ---
-if(NOT LLVM_BIN AND DEFINED ENV{LLVM_BIN})
-    set(LLVM_BIN "$ENV{LLVM_BIN}")
-endif()
-if(LLVM_BIN)
-    set(_clang_cl  "${LLVM_BIN}/clang-cl")
-    set(_lld_link  "${LLVM_BIN}/lld-link")
-    set(_llvm_lib  "${LLVM_BIN}/llvm-lib")
-    set(_llvm_rc   "${LLVM_BIN}/llvm-rc")
-else()
-    set(_clang_cl  clang-cl)
-    set(_lld_link  lld-link)
-    set(_llvm_lib  llvm-lib)
-    set(_llvm_rc   llvm-rc)
-endif()
-
-set(CMAKE_C_COMPILER   "${_clang_cl}")
-set(CMAKE_CXX_COMPILER "${_clang_cl}")
-set(CMAKE_LINKER       "${_lld_link}")
-set(CMAKE_AR           "${_llvm_lib}")
-set(CMAKE_RC_COMPILER  "${_llvm_rc}")
-
-# 32-bit MSVC target triple for both languages.
-set(CMAKE_C_COMPILER_TARGET   i686-pc-windows-msvc)
-set(CMAKE_CXX_COMPILER_TARGET i686-pc-windows-msvc)
-
-# Compile-only the toolchain probe so configure doesn't depend on a linkable
-# entry point. Real link validation happens when we build the DLLs.
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-
-# MSVC-system include dirs from the splat. /imsvc keeps them on the system path
-# (no -Wnonportable-include-path noise from the SDK's own headers).
-set(_xwin_incs
-    "/imsvc${XWIN_SPLAT}/crt/include"
-    "/imsvc${XWIN_SPLAT}/sdk/include/ucrt"
-    "/imsvc${XWIN_SPLAT}/sdk/include/um"
-    "/imsvc${XWIN_SPLAT}/sdk/include/shared")
-string(JOIN " " _xwin_incflags ${_xwin_incs})
-
-# -fasm-blocks: parse the MS-style __asm jmp thunks in proxy/ijl15.cpp.
-set(_common_flags "-fms-compatibility -fms-extensions -fasm-blocks ${_xwin_incflags}")
-set(CMAKE_C_FLAGS_INIT   "${_common_flags}")
-set(CMAKE_CXX_FLAGS_INIT "${_common_flags}")
-
-# Library search paths for lld-link.
-set(_xwin_libs
-    "/libpath:${XWIN_SPLAT}/crt/lib/x86"
-    "/libpath:${XWIN_SPLAT}/sdk/lib/um/x86"
-    "/libpath:${XWIN_SPLAT}/sdk/lib/ucrt/x86")
-string(JOIN " " _xwin_libflags ${_xwin_libs})
-set(_link_init "/machine:x86 ${_xwin_libflags}")
-set(CMAKE_EXE_LINKER_FLAGS_INIT    "${_link_init}")
-set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_link_init}")
-set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_link_init}")
-
-# Only search the splat for headers/libs; never the (empty) host Windows roots.
-set(CMAKE_FIND_ROOT_PATH "${XWIN_SPLAT}")
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-```
+**CORRECTION (from bring-up):** the toolchain file resolves `lld-link` from a
+SEPARATE keg (`LLD_BIN`) than clang-cl/llvm-lib/llvm-rc (`LLVM_BIN`), per the
+Task 1 finding. The committed file is the source of truth; create
+`cmake/toolchains/clang-cl-win32.cmake` matching the repository copy. Its shape:
+`CMAKE_SYSTEM_NAME=Windows`, `_PROCESSOR=x86`; resolve the splat from
+`-DXWIN_SPLAT`/env/`~/.xwin-splat`; resolve tools from `-DLLVM_BIN` and `-DLLD_BIN`
+(env fallback, then bare names on PATH); set `CMAKE_{C,CXX}_COMPILER=clang-cl`,
+`CMAKE_LINKER=lld-link`, `CMAKE_AR=llvm-lib`, `CMAKE_RC_COMPILER=llvm-rc`;
+`CMAKE_{C,CXX}_COMPILER_TARGET=i686-pc-windows-msvc`;
+`CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` (compile-only probe);
+`/imsvc` include flags for `crt/include` + `sdk/include/{ucrt,um,shared}`;
+`-fms-compatibility -fms-extensions -fasm-blocks` in `CMAKE_{C,CXX}_FLAGS_INIT`;
+`/machine:x86` + `/libpath:` for `crt/lib/x86` + `sdk/lib/{um,ucrt}/x86` in the
+linker `*_INIT` flags; and `CMAKE_FIND_ROOT_PATH` pinned to the splat.
 
 - [ ] **Step 2: Verify configure succeeds (the toolchain probe)**
 
-Run:
+Run (note BOTH `LLVM_BIN` and `LLD_BIN`):
 ```bash
-LLVM_BIN="$(brew --prefix llvm)/bin" \
+LLVM_BIN="$(brew --prefix llvm)/bin" LLD_BIN="$(brew --prefix lld)/bin" \
 cmake -G Ninja -B /tmp/wsl-cfg-probe \
   --toolchain "$PWD/cmake/toolchains/clang-cl-win32.cmake" \
   -DBUILD_REGION=GMS -DBUILD_MAJOR_VERSION=83 -DBUILD_MINOR_VERSION=1
 ```
 Expected: ends with `-- Configuring done` / `-- Generating done`, with
-`-- The C compiler identification is Clang` and `MSVC`-like behavior detected.
-If it fails at "The C compiler ... is not able to compile a simple test program",
-read `/tmp/wsl-cfg-probe/CMakeFiles/CMakeError.log` — that is the precise bring-up
-signal (usually a missing `/imsvc` path or a tool not found). Fix the toolchain file
-and re-run until configure passes.
+`-- The C compiler identification is Clang 22.1.7 with MSVC-like command-line`.
+(Bring-up result: PASS.) If it instead fails at "The C compiler ... is not able to
+compile a simple test program", read
+`/tmp/wsl-cfg-probe/CMakeFiles/CMakeError.log` — usually a missing `/imsvc` path or
+a tool not found. Fix the toolchain file and re-run until configure passes.
 
 - [ ] **Step 3: Clean up the probe dir**
 

--- a/docs/tasks/wsl-cross-compile/plan.md
+++ b/docs/tasks/wsl-cross-compile/plan.md
@@ -1,0 +1,505 @@
+# WSL clang-cl Cross-Compile Check Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Claude configure, compile, and link the Win32 MSVC-ABI edit DLLs entirely inside WSL (via `clang-cl` + `lld-link` with MSVC headers/libs from `xwin`), so compile/link errors surface before the git-branch handoff.
+
+**Architecture:** A CMake toolchain file points `clang-cl`/`lld-link` at an `xwin`-produced splat of the MSVC CRT + Windows SDK, targeting `i686-pc-windows-msvc`. A driver script wraps `cmake -G Ninja` + build for a given region/version. CI on `windows-2025` stays the authoritative artifact source; this is a dev-only check loop. The existing vendored `common/detours.lib` (i386 COFF) links directly.
+
+**Tech Stack:** clang-cl, lld-link, llvm-lib, ninja, xwin, CMake 4.3.2, bash.
+
+**Design reference:** `docs/tasks/wsl-cross-compile/design.md`
+
+**Note on test style:** This is toolchain bring-up, not application code. "Tests" are
+build/inspection commands with concrete expected output. The discipline is the same:
+verify each step before moving on, commit frequently. Task 3 (the toolchain file) is the
+empirical bring-up point — if any single task needs a debug iteration, it is that one;
+its verification command is written to reveal the failure precisely.
+
+---
+
+### Task 1: Install host toolchain (clang-cl, lld-link, ninja)
+
+**Files:** none (host environment only).
+
+- [ ] **Step 1: Check what's already present**
+
+Run:
+```bash
+for t in clang-cl lld-link llvm-lib ninja; do printf "%-12s" "$t:"; command -v $t || echo MISSING; done
+```
+Expected: likely all `MISSING` on a fresh WSL (only `cmake` is preinstalled via Homebrew).
+
+- [ ] **Step 2: Install LLVM (provides clang-cl, lld-link, llvm-lib, llvm-rc) and ninja via Homebrew**
+
+Homebrew is already on this machine (`/home/linuxbrew/.linuxbrew`), so no sudo is needed.
+
+Run:
+```bash
+brew install llvm ninja
+```
+Expected: completes (llvm is ~1.5 GB; may take several minutes).
+
+- [ ] **Step 3: Put the LLVM bin dir on PATH and verify the four tools resolve**
+
+`brew install llvm` is keg-only, so its tools are NOT symlinked into the default
+Homebrew bin. Resolve the prefix and verify:
+```bash
+LLVM_BIN="$(brew --prefix llvm)/bin"
+for t in clang-cl lld-link llvm-lib llvm-rc ninja; do printf "%-12s" "$t:"; "$LLVM_BIN/$t" --version >/dev/null 2>&1 && echo "OK ($LLVM_BIN/$t)" || command -v "$t" || echo MISSING; done
+```
+Expected: `clang-cl`, `lld-link`, `llvm-lib`, `llvm-rc` resolve under `$(brew --prefix llvm)/bin`; `ninja` resolves on PATH. Record `LLVM_BIN` — the driver script (Task 4) and toolchain file (Task 3) reference these tools by absolute path so a non-interactive shell finds them.
+
+- [ ] **Step 4: Capture the LLVM bin path for later tasks**
+
+Run:
+```bash
+echo "LLVM_BIN=$(brew --prefix llvm)/bin"
+```
+Expected: prints e.g. `LLVM_BIN=/home/linuxbrew/.linuxbrew/opt/llvm/bin`. No commit (host setup only).
+
+---
+
+### Task 2: Install xwin and generate the MSVC/SDK splat
+
+**Files:** none tracked (splat lives outside the git tree at `~/.xwin-splat`).
+
+- [ ] **Step 1: Install the xwin binary**
+
+Prefer a prebuilt release binary (no Rust toolchain needed). Run:
+```bash
+XWIN_VER=0.6.6
+cd /tmp
+curl -fsSL "https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VER}/xwin-${XWIN_VER}-x86_64-unknown-linux-musl.tar.gz" -o xwin.tgz
+tar -xzf xwin.tgz
+install -m755 "xwin-${XWIN_VER}-x86_64-unknown-linux-musl/xwin" "$(brew --prefix)/bin/xwin"
+xwin --version
+```
+Expected: prints `xwin 0.6.6` (or the pinned version). If the download 404s, fall back to `cargo install xwin` (requires `brew install rust` first).
+
+- [ ] **Step 2: Download + splat the CRT and Windows SDK (Win32/x86 only)**
+
+This accepts the Microsoft redistributable license and writes ~1 GB to `~/.xwin-splat`.
+Run:
+```bash
+xwin --accept-license --arch x86 splat --output "$HOME/.xwin-splat"
+```
+Expected: completes with a `crt/` and `sdk/` tree under `~/.xwin-splat`. (Downloads are cached under `./.xwin-cache`; delete `/tmp/.xwin-cache` afterward if created.)
+
+- [ ] **Step 3: Verify the splat contains the headers and libs this project needs**
+
+Run:
+```bash
+S="$HOME/.xwin-splat"
+ls "$S/crt/include/vcruntime.h" \
+   "$S/sdk/include/um/Windows.h" \
+   "$S/crt/lib/x86/libcmt.lib" \
+   "$S/crt/lib/x86/comsuppw.lib" \
+   "$S/sdk/lib/um/x86/Ws2_32.lib" \
+   "$S/sdk/lib/um/x86/winmm.lib" \
+   "$S/sdk/lib/ucrt/x86/ucrt.lib"
+```
+Expected: every path lists without error. **This step retires two tracked risks from the design at once:** `comsuppw.lib` presence and SDK header availability. If `comsuppw.lib` is missing, stop and report — it is required by the COM-using headers in `common/` and there is no clean substitute.
+
+- [ ] **Step 4: Confirm case-variant resolution for bare-name libs**
+
+The code references `Ws2_32.lib`/`WS2_32.lib` (mixed case) via both CMake and
+`#pragma comment(lib, ...)`. On a case-sensitive FS the linker must still find them.
+Run:
+```bash
+S="$HOME/.xwin-splat"
+ls -la "$S/sdk/lib/um/x86/" | grep -i 'ws2_32\.lib'
+```
+Expected: a `ws2_32.lib` entry exists (xwin lowercases SDK lib names and/or creates case symlinks by default). Note the actual casing — if only one case exists and it differs from a `#pragma comment(lib, ...)` spelling, that is the case-sensitivity risk materializing; the fallback is a symlink added in Task 4's script. No commit (host setup only).
+
+---
+
+### Task 3: Write the CMake toolchain file
+
+**Files:**
+- Create: `cmake/toolchains/clang-cl-win32.cmake`
+
+- [ ] **Step 1: Write the toolchain file**
+
+Create `cmake/toolchains/clang-cl-win32.cmake` with exactly:
+```cmake
+# Cross-compile the Win32 MSVC-ABI edit DLLs in WSL with clang-cl + lld-link,
+# using an xwin-produced splat of the MSVC CRT + Windows SDK. Dev-only check
+# loop; CI on windows-2025 remains authoritative. See
+# docs/tasks/wsl-cross-compile/design.md.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+
+# --- locate the xwin splat (override with -DXWIN_SPLAT=... or env XWIN_SPLAT) ---
+if(NOT XWIN_SPLAT)
+    if(DEFINED ENV{XWIN_SPLAT})
+        set(XWIN_SPLAT "$ENV{XWIN_SPLAT}")
+    else()
+        set(XWIN_SPLAT "$ENV{HOME}/.xwin-splat")
+    endif()
+endif()
+if(NOT EXISTS "${XWIN_SPLAT}/crt/include")
+    message(FATAL_ERROR
+        "xwin splat not found at '${XWIN_SPLAT}'. "
+        "Run scripts/wsl-build.sh (it checks/installs) or see "
+        "docs/tasks/wsl-cross-compile/README.md.")
+endif()
+
+# --- locate the LLVM tools (override with -DLLVM_BIN=... or env LLVM_BIN) ---
+if(NOT LLVM_BIN AND DEFINED ENV{LLVM_BIN})
+    set(LLVM_BIN "$ENV{LLVM_BIN}")
+endif()
+if(LLVM_BIN)
+    set(_clang_cl  "${LLVM_BIN}/clang-cl")
+    set(_lld_link  "${LLVM_BIN}/lld-link")
+    set(_llvm_lib  "${LLVM_BIN}/llvm-lib")
+    set(_llvm_rc   "${LLVM_BIN}/llvm-rc")
+else()
+    set(_clang_cl  clang-cl)
+    set(_lld_link  lld-link)
+    set(_llvm_lib  llvm-lib)
+    set(_llvm_rc   llvm-rc)
+endif()
+
+set(CMAKE_C_COMPILER   "${_clang_cl}")
+set(CMAKE_CXX_COMPILER "${_clang_cl}")
+set(CMAKE_LINKER       "${_lld_link}")
+set(CMAKE_AR           "${_llvm_lib}")
+set(CMAKE_RC_COMPILER  "${_llvm_rc}")
+
+# 32-bit MSVC target triple for both languages.
+set(CMAKE_C_COMPILER_TARGET   i686-pc-windows-msvc)
+set(CMAKE_CXX_COMPILER_TARGET i686-pc-windows-msvc)
+
+# Compile-only the toolchain probe so configure doesn't depend on a linkable
+# entry point. Real link validation happens when we build the DLLs.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# MSVC-system include dirs from the splat. /imsvc keeps them on the system path
+# (no -Wnonportable-include-path noise from the SDK's own headers).
+set(_xwin_incs
+    "/imsvc${XWIN_SPLAT}/crt/include"
+    "/imsvc${XWIN_SPLAT}/sdk/include/ucrt"
+    "/imsvc${XWIN_SPLAT}/sdk/include/um"
+    "/imsvc${XWIN_SPLAT}/sdk/include/shared")
+string(JOIN " " _xwin_incflags ${_xwin_incs})
+
+# -fasm-blocks: parse the MS-style __asm jmp thunks in proxy/ijl15.cpp.
+set(_common_flags "-fms-compatibility -fms-extensions -fasm-blocks ${_xwin_incflags}")
+set(CMAKE_C_FLAGS_INIT   "${_common_flags}")
+set(CMAKE_CXX_FLAGS_INIT "${_common_flags}")
+
+# Library search paths for lld-link.
+set(_xwin_libs
+    "/libpath:${XWIN_SPLAT}/crt/lib/x86"
+    "/libpath:${XWIN_SPLAT}/sdk/lib/um/x86"
+    "/libpath:${XWIN_SPLAT}/sdk/lib/ucrt/x86")
+string(JOIN " " _xwin_libflags ${_xwin_libs})
+set(_link_init "/machine:x86 ${_xwin_libflags}")
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${_link_init}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_link_init}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_link_init}")
+
+# Only search the splat for headers/libs; never the (empty) host Windows roots.
+set(CMAKE_FIND_ROOT_PATH "${XWIN_SPLAT}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+```
+
+- [ ] **Step 2: Verify configure succeeds (the toolchain probe)**
+
+Run:
+```bash
+LLVM_BIN="$(brew --prefix llvm)/bin" \
+cmake -G Ninja -B /tmp/wsl-cfg-probe \
+  --toolchain "$PWD/cmake/toolchains/clang-cl-win32.cmake" \
+  -DBUILD_REGION=GMS -DBUILD_MAJOR_VERSION=83 -DBUILD_MINOR_VERSION=1
+```
+Expected: ends with `-- Configuring done` / `-- Generating done`, with
+`-- The C compiler identification is Clang` and `MSVC`-like behavior detected.
+If it fails at "The C compiler ... is not able to compile a simple test program",
+read `/tmp/wsl-cfg-probe/CMakeFiles/CMakeError.log` — that is the precise bring-up
+signal (usually a missing `/imsvc` path or a tool not found). Fix the toolchain file
+and re-run until configure passes.
+
+- [ ] **Step 3: Clean up the probe dir**
+
+Run:
+```bash
+rm -rf /tmp/wsl-cfg-probe
+```
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmake/toolchains/clang-cl-win32.cmake
+git commit -m "build(wsl): clang-cl + xwin cross-compile toolchain file"
+```
+
+---
+
+### Task 4: Write the driver script
+
+**Files:**
+- Create: `scripts/wsl-build.sh`
+- Modify: `.gitignore` (add `build-wsl/`)
+
+- [ ] **Step 1: Add the build dir to .gitignore**
+
+The existing `build` and `cmake-*` patterns do NOT match `build-wsl`. Append a line
+to `.gitignore`:
+```
+build-wsl
+```
+
+- [ ] **Step 2: Write the driver script**
+
+Create `scripts/wsl-build.sh` with exactly:
+```bash
+#!/usr/bin/env bash
+# Dev-only WSL cross-compile check loop. Configures + builds the Win32 edit
+# DLLs with clang-cl + lld-link against an xwin splat. NOT the authoritative
+# build -- CI on windows-2025 owns that. See docs/tasks/wsl-cross-compile/.
+#
+# Usage: scripts/wsl-build.sh [REGION] [MAJOR] [MINOR] [TARGET]
+#   defaults: GMS 83 1  (all edit DLLs + proxy)
+set -euo pipefail
+
+REGION="${1:-GMS}"
+MAJOR="${2:-83}"
+MINOR="${3:-1}"
+TARGET="${4:-}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-wsl"
+TOOLCHAIN="${REPO_ROOT}/cmake/toolchains/clang-cl-win32.cmake"
+SPLAT="${XWIN_SPLAT:-$HOME/.xwin-splat}"
+
+# Resolve LLVM bin (keg-only Homebrew llvm is not on the default PATH).
+if [[ -z "${LLVM_BIN:-}" ]]; then
+    if command -v brew >/dev/null 2>&1; then
+        LLVM_BIN="$(brew --prefix llvm)/bin"
+    fi
+fi
+export LLVM_BIN
+
+die() { echo "error: $*" >&2; echo "see docs/tasks/wsl-cross-compile/README.md" >&2; exit 1; }
+
+# Preflight: tools + splat.
+[[ -n "${LLVM_BIN:-}" && -x "${LLVM_BIN}/clang-cl" ]] || die "clang-cl not found under '${LLVM_BIN:-unset}' (Task 1: brew install llvm)"
+command -v ninja >/dev/null 2>&1 || die "ninja not found (Task 1: brew install ninja)"
+[[ -d "${SPLAT}/crt/include" ]] || die "xwin splat missing at '${SPLAT}' (Task 2: xwin splat)"
+
+echo ">> ${REGION} v${MAJOR}.${MINOR}  splat=${SPLAT}  llvm=${LLVM_BIN}"
+cmake -G Ninja -B "${BUILD_DIR}" \
+    --toolchain "${TOOLCHAIN}" \
+    -DXWIN_SPLAT="${SPLAT}" \
+    -DBUILD_REGION="${REGION}" \
+    -DBUILD_MAJOR_VERSION="${MAJOR}" \
+    -DBUILD_MINOR_VERSION="${MINOR}"
+
+if [[ -n "${TARGET}" ]]; then
+    cmake --build "${BUILD_DIR}" --target "${TARGET}"
+else
+    cmake --build "${BUILD_DIR}"
+fi
+echo ">> OK"
+```
+
+- [ ] **Step 3: Make it executable**
+
+Run:
+```bash
+chmod +x scripts/wsl-build.sh
+```
+Expected: no output.
+
+- [ ] **Step 4: MVP proof — link the simplest edit DLL**
+
+Run:
+```bash
+./scripts/wsl-build.sh GMS 83 1 skip-logo
+```
+Expected: ends with `>> OK`, and the DLL exists:
+```bash
+ls -la build-wsl/skip-logo/*.dll
+```
+Expected: a `skip-logo-*.dll` is listed. This is success-ladder step 1 from the
+design — a real compile **and link** in WSL. If link fails on a missing symbol,
+the error names the lib/symbol; cross-check against `cmake/CommonLib.cmake`'s lib
+list and the splat (`Task 2 Step 3`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/wsl-build.sh .gitignore
+git commit -m "build(wsl): driver script for clang-cl cross-compile check loop"
+```
+
+---
+
+### Task 5: Build the full default target (all edit DLLs + proxy) for GMS 83.1
+
+**Files:** none (exercises the existing tree end-to-end).
+
+This task surfaces the remaining design risks together: the `__asm` thunks
+(`proxy/ijl15.cpp`, needs `-fasm-blocks`), `comsuppw.lib`, SEH (`memedit.cpp`),
+and the vendored `common/detours.lib` link.
+
+- [ ] **Step 1: Build everything for GMS 83.1**
+
+Run:
+```bash
+./scripts/wsl-build.sh GMS 83 1
+```
+Expected: ends with `>> OK`.
+
+- [ ] **Step 2: Verify every edit DLL + proxy produced a .dll**
+
+Run:
+```bash
+find build-wsl -name '*.dll' | sort
+```
+Expected: a `.dll` for each of bypass, doom-fix, enable-minimize, no-patcher,
+no-beginner-party-block, no-enter-mts-map-restriction, no-ad-balloon, redirect,
+skip-logo, window-mode, and proxy (11 DLLs).
+
+- [ ] **Step 3: If the `proxy` inline-asm thunks fail to compile**
+
+`-fasm-blocks` (set in the toolchain file) should handle the six
+`__asm jmp dword ptr[...]` thunks. If clang's MS-asm parser still rejects them,
+do NOT silently drop proxy. Build everything except proxy to confirm the rest is
+green, and report the proxy failure for a decision (per design: proxy may stay
+compile-only, or get a flagged source tweak):
+```bash
+for t in bypass doom-fix enable-minimize no-patcher no-beginner-party-block \
+         no-enter-mts-map-restriction no-ad-balloon redirect skip-logo window-mode; do
+    ./scripts/wsl-build.sh GMS 83 1 "$t"
+done
+```
+Expected: each `>> OK`. (Skip this step entirely if Step 1 already passed.)
+
+- [ ] **Step 4: No commit**
+
+This task changes no tracked files — it is a verification gate. Proceed only once
+Step 1 (or Step 3's fallback) is green.
+
+---
+
+### Task 6: Stretch — verify the other five matrix configs configure + build
+
+**Files:** none.
+
+These differ from GMS 83.1 only by the included memory-map `.cmake` and compile
+defs, so they should build with no further toolchain work.
+
+- [ ] **Step 1: Build each remaining CI config**
+
+Run:
+```bash
+set -e
+./scripts/wsl-build.sh GMS 84 1
+./scripts/wsl-build.sh GMS 87 1
+./scripts/wsl-build.sh GMS 95 1
+./scripts/wsl-build.sh GMS 111 1
+./scripts/wsl-build.sh JMS 185 1
+```
+Expected: each run ends with `>> OK`. (Each reconfigures `build-wsl` for the new
+region/version.) If a specific version fails to compile, that is a real
+version-gated source issue worth reporting — not a toolchain problem — since the
+toolchain is identical across configs.
+
+- [ ] **Step 2: No commit**
+
+Verification gate only.
+
+---
+
+### Task 7: Write the dev-doc
+
+**Files:**
+- Create: `docs/tasks/wsl-cross-compile/README.md`
+
+- [ ] **Step 1: Write the README**
+
+Create `docs/tasks/wsl-cross-compile/README.md` with exactly:
+```markdown
+# WSL cross-compile check loop
+
+Compile + link the Win32 edit DLLs inside WSL with `clang-cl` + `lld-link`, to
+catch compile/link errors without a Windows round-trip.
+
+**This is a dev-only check, not the authoritative build.** CI on `windows-2025`
+(`.github/workflows/_build.yml`) owns the shipping artifacts. A successful WSL
+build means "it compiles and links"; it is *not* a guarantee of byte/ABI parity
+with the MSVC build, and the produced DLLs are not intended to be injected into
+the client. To actually run a DLL, build on Windows.
+
+## One-time setup
+
+1. Toolchain (Homebrew, no sudo):
+   ```bash
+   brew install llvm ninja
+   ```
+2. xwin + the MSVC/SDK splat (~1 GB, accepts the MS redistributable license):
+   ```bash
+   xwin --accept-license --arch x86 splat --output "$HOME/.xwin-splat"
+   ```
+   (Install the `xwin` binary first — see the project plan, Task 2.)
+
+## Usage
+
+```bash
+# defaults to GMS 83 1, all edit DLLs + proxy
+./scripts/wsl-build.sh
+
+# specific region/version
+./scripts/wsl-build.sh GMS 87 1
+
+# single target (fast iteration)
+./scripts/wsl-build.sh GMS 83 1 skip-logo
+```
+
+Build output lands in `build-wsl/` (gitignored).
+
+## Overrides
+
+- `XWIN_SPLAT` — splat location (default `~/.xwin-splat`).
+- `LLVM_BIN`  — LLVM tools dir (default `$(brew --prefix llvm)/bin`).
+
+## Supported configs
+
+GMS 83.1, 84.1, 87.1, 95.1, 111.1; JMS 185.1 — matching the CI matrix.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/tasks/wsl-cross-compile/README.md
+git commit -m "docs(wsl-cross-compile): dev-doc for the WSL check loop"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- clang-cl + lld-link + i686 target → Task 3. ✓
+- xwin splat (outside tree, env-overridable) → Task 2, Task 3 (`XWIN_SPLAT`). ✓
+- Reuse vendored `common/detours.lib` → exercised in Task 5 (no new code; CommonLib.cmake already references it by absolute path). ✓
+- Ninja generator → Task 3 verify + Task 4 script. ✓
+- `-fasm-blocks` for proxy asm → Task 3 toolchain file; risk-handled in Task 5 Step 3. ✓
+- comsuppw.lib risk → Task 2 Step 3 (explicit check). ✓
+- Header case-sensitivity risk → Task 2 Step 4 (explicit check + fallback). ✓
+- Driver script defaults GMS 83.1, all DLLs → Task 4. ✓
+- Success ladder (skip-logo → full 83.1 → matrix) → Tasks 4/5/6. ✓
+- Dev-doc, dev-only caveat → Task 7. ✓
+- No CI changes, no source changes (asm flagged, not edited) → respected throughout. ✓
+
+**Placeholder scan:** No TBD/TODO; every code/config step shows full content; verification commands have concrete expected output.
+
+**Type/name consistency:** `XWIN_SPLAT`, `LLVM_BIN`, `build-wsl`, `cmake/toolchains/clang-cl-win32.cmake`, and `scripts/wsl-build.sh` are spelled identically across the toolchain file, the driver script, and the docs.

--- a/docs/tasks/wsl-cross-compile/plan.md
+++ b/docs/tasks/wsl-cross-compile/plan.md
@@ -91,13 +91,19 @@ Expected: prints `xwin 0.9.0`. In 0.9.0 the `--arch` filter is a **global** opti
 
 This accepts the Microsoft redistributable license and writes ~1 GB to `~/.xwin-splat`.
 
-**CORRECTION (from bring-up):** xwin *moves* files from its cache to the output by
-default. In this WSL `/tmp` (cache) and `/home` (output) are different filesystems,
-so the move fails with `Invalid cross-device link (EXDEV)`. Use `--copy` to copy
-instead of move. Keep the cache on `/tmp` to reuse any prior download.
+**CORRECTIONS (from bring-up):**
+- xwin *moves* files from its cache to the output by default. In this WSL `/tmp`
+  (cache) and `/home` (output) are different filesystems, so the move fails with
+  `Invalid cross-device link (EXDEV)`. Use `--copy`. Keep the cache on `/tmp` to
+  reuse any prior download.
+- `common/pch.h` includes `<atlstr.h>` (ATL `CString`), which the default splat
+  omits → add the global `--include-atl`.
+- A Debug build links the debug CRT (`msvcrtd.lib`, `msvcprtd.lib`,
+  `comsuppwd.lib`), which the default splat omits → add the splat-level
+  `--include-debug-libs`. (Without it, Release links but Debug fails.)
 ```bash
-xwin --accept-license --arch x86 --cache-dir /tmp/.xwin-cache \
-     splat --output "$HOME/.xwin-splat" --copy
+xwin --accept-license --arch x86 --include-atl --cache-dir /tmp/.xwin-cache \
+     splat --output "$HOME/.xwin-splat" --copy --include-debug-libs
 ```
 Expected: completes silently with a `crt/` and `sdk/` tree under `~/.xwin-splat`.
 Symlinks are on by default — that is what fixes `#include <Windows.h>` casing.
@@ -108,14 +114,16 @@ Run:
 ```bash
 S="$HOME/.xwin-splat"
 ls "$S/crt/include/vcruntime.h" \
+   "$S/crt/include/atlstr.h" \
    "$S/sdk/include/um/Windows.h" \
    "$S/crt/lib/x86/libcmt.lib" \
    "$S/crt/lib/x86/comsuppw.lib" \
-   "$S/sdk/lib/um/x86/Ws2_32.lib" \
+   "$S/crt/lib/x86/msvcrtd.lib" \
+   "$S/crt/lib/x86/comsuppwd.lib" \
    "$S/sdk/lib/um/x86/winmm.lib" \
    "$S/sdk/lib/ucrt/x86/ucrt.lib"
 ```
-Expected: every path lists without error. **This step retires two tracked risks from the design at once:** `comsuppw.lib` presence and SDK header availability. If `comsuppw.lib` is missing, stop and report — it is required by the COM-using headers in `common/` and there is no clean substitute.
+Expected: every path lists without error. **This step retires three tracked risks from the design at once:** `comsuppw.lib` presence (+ its debug twin `comsuppwd.lib`), the ATL header `atlstr.h` (`--include-atl`), and the debug CRT `msvcrtd.lib` (`--include-debug-libs`). If `comsuppw.lib`/`atlstr.h` are missing, stop and report — they are required by the COM/ATL headers in `common/` and there is no clean substitute. (Note: the SDK lib `Ws2_32.lib` mixed-case spelling is verified separately in Step 4; xwin does not emit that exact permutation.)
 
 - [ ] **Step 4: Confirm case-variant resolution for bare-name libs**
 
@@ -159,6 +167,17 @@ Task 1 finding. The committed file is the source of truth; create
 `-fms-compatibility -fms-extensions -fasm-blocks` in `CMAKE_{C,CXX}_FLAGS_INIT`;
 `/machine:x86` + `/libpath:` for `crt/lib/x86` + `sdk/lib/{um,ucrt}/x86` in the
 linker `*_INIT` flags; and `CMAKE_FIND_ROOT_PATH` pinned to the splat.
+
+**CORRECTIONS (from bring-up):**
+- `-fasm-blocks` is an *unknown* clang-cl arg AND unnecessary — clang-cl compiles
+  the `proxy/ijl15.cpp` `__asm jmp dword ptr[...]` thunks under `-fms-extensions`
+  alone (verified in isolation). The flag is omitted.
+- Homebrew's LLVM ships no `llvm-mt`, and CMake's `find_program(mt)` otherwise
+  grabs the Linux magnetic-tape tool `/usr/bin/mt`, breaking the post-link
+  manifest step. The file sets `CMAKE_MT=/bin/true` (a real, found path so
+  find_program won't override it; exits 0 so CMake's vs_link wrapper reads
+  "manifest not updated" and keeps the linked DLL). An empty value does NOT work
+  — find_program re-searches and re-finds `/usr/bin/mt`.
 
 - [ ] **Step 2: Verify configure succeeds (the toolchain probe)**
 
@@ -208,6 +227,13 @@ build-wsl
 ```
 
 - [ ] **Step 2: Write the driver script**
+
+**CORRECTIONS (from bring-up):** the committed `scripts/wsl-build.sh` differs from
+the draft below in two ways, both already explained above: (1) it resolves BOTH
+`LLVM_BIN` (llvm keg) and `LLD_BIN` (lld keg) and passes both as `-D`; (2) it has
+an `ensure_lib_symlink` preflight that idempotently creates the missing
+`Ws2_32.lib` case-alias in the splat. The committed file is the source of truth;
+the block below is the original draft kept for reference.
 
 Create `scripts/wsl-build.sh` with exactly:
 ```bash

--- a/docs/tasks/wsl-cross-compile/plan.md
+++ b/docs/tasks/wsl-cross-compile/plan.md
@@ -324,8 +324,20 @@ git commit -m "build(wsl): driver script for clang-cl cross-compile check loop"
 **Files:** none (exercises the existing tree end-to-end).
 
 This task surfaces the remaining design risks together: the `__asm` thunks
-(`proxy/ijl15.cpp`, needs `-fasm-blocks`), `comsuppw.lib`, SEH (`memedit.cpp`),
-and the vendored `common/detours.lib` link.
+(`proxy/ijl15.cpp`), `comsuppw.lib`, SEH (`memedit.cpp`), and the vendored
+`common/detours.lib` link.
+
+**FINDING (from bring-up):** one more toolchain-difference surfaced here —
+`bypass/client_exception.cpp` uses `_CxxThrowException` / `_ThrowInfo`, which it
+relies on being visible "through `<windows.h>`". On MSVC that holds because the
+c1xx frontend force-injects `<ehdata_forceinclude.h>` into every C++ TU; clang-cl
+does not, and that header is not directly includable (MSVC pre-pass tokens). Fix
+(WSL-only, no client-source change): a force-include shim
+`cmake/toolchains/wsl-eh-forceinclude.h` declaring just those two symbols with the
+MSVC ABI signature, applied via `/FI` to **CXX flags only** (it is `extern "C"`,
+which is a syntax error in C — it broke CMake's C compiler probe until scoped to
+CXX). CI never sees the shim, so the C2733/C2371 clashes the .cpp comment warns
+about cannot occur.
 
 - [ ] **Step 1: Build everything for GMS 83.1**
 

--- a/scripts/wsl-build.sh
+++ b/scripts/wsl-build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Dev-only WSL cross-compile check loop. Configures + builds the Win32 edit
+# DLLs with clang-cl + lld-link against an xwin splat. NOT the authoritative
+# build -- CI on windows-2025 owns that. See docs/tasks/wsl-cross-compile/.
+#
+# Usage: scripts/wsl-build.sh [REGION] [MAJOR] [MINOR] [TARGET]
+#   defaults: GMS 83 1  (all edit DLLs + proxy)
+set -euo pipefail
+
+REGION="${1:-GMS}"
+MAJOR="${2:-83}"
+MINOR="${3:-1}"
+TARGET="${4:-}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-wsl"
+TOOLCHAIN="${REPO_ROOT}/cmake/toolchains/clang-cl-win32.cmake"
+SPLAT="${XWIN_SPLAT:-$HOME/.xwin-splat}"
+
+# Resolve the two keg-only Homebrew prefixes. clang-cl/llvm-lib/llvm-rc live in
+# the llvm keg; lld-link in the separate lld keg.
+if [[ -z "${LLVM_BIN:-}" ]] && command -v brew >/dev/null 2>&1; then
+    LLVM_BIN="$(brew --prefix llvm)/bin"
+fi
+if [[ -z "${LLD_BIN:-}" ]] && command -v brew >/dev/null 2>&1; then
+    LLD_BIN="$(brew --prefix lld)/bin"
+fi
+export LLVM_BIN LLD_BIN
+
+die() { echo "error: $*" >&2; echo "see docs/tasks/wsl-cross-compile/README.md" >&2; exit 1; }
+
+# --- preflight: tools + splat ---
+[[ -n "${LLVM_BIN:-}" && -x "${LLVM_BIN}/clang-cl" ]] || die "clang-cl not found under '${LLVM_BIN:-unset}' (Task 1: brew install llvm)"
+[[ -n "${LLD_BIN:-}"  && -x "${LLD_BIN}/lld-link"  ]] || die "lld-link not found under '${LLD_BIN:-unset}' (Task 1: brew install lld)"
+command -v ninja >/dev/null 2>&1 || die "ninja not found (Task 1: brew install ninja)"
+[[ -d "${SPLAT}/crt/include" ]] || die "xwin splat missing at '${SPLAT}' (Task 2: xwin splat)"
+
+# --- self-heal known SDK lib case gaps ---
+# xwin symlinks most casings, but cmake/CommonLib.cmake references the exact
+# mixed-case spelling 'Ws2_32.lib' which xwin does not emit. Create it (and any
+# future known gaps) idempotently, pointing at the real on-disk file.
+ensure_lib_symlink() {
+    local dir="$1" want="$2" real="$3"
+    [[ -e "${dir}/${want}" ]] && return 0
+    [[ -e "${dir}/${real}" ]] || { echo "warn: ${dir}/${real} absent; cannot alias ${want}" >&2; return 0; }
+    ln -sf "${real}" "${dir}/${want}"
+    echo ">> aliased ${want} -> ${real} in ${dir}"
+}
+ensure_lib_symlink "${SPLAT}/sdk/lib/um/x86" "Ws2_32.lib" "WS2_32.Lib"
+
+echo ">> ${REGION} v${MAJOR}.${MINOR}  splat=${SPLAT}"
+echo ">> llvm=${LLVM_BIN}  lld=${LLD_BIN}"
+cmake -G Ninja -B "${BUILD_DIR}" \
+    --toolchain "${TOOLCHAIN}" \
+    -DXWIN_SPLAT="${SPLAT}" \
+    -DLLVM_BIN="${LLVM_BIN}" \
+    -DLLD_BIN="${LLD_BIN}" \
+    -DBUILD_REGION="${REGION}" \
+    -DBUILD_MAJOR_VERSION="${MAJOR}" \
+    -DBUILD_MINOR_VERSION="${MINOR}"
+
+if [[ -n "${TARGET}" ]]; then
+    cmake --build "${BUILD_DIR}" --target "${TARGET}"
+else
+    cmake --build "${BUILD_DIR}"
+fi
+echo ">> OK"


### PR DESCRIPTION
## Summary

Adds a **dev-only** way to compile + link the Win32 edit DLLs entirely in WSL via `clang-cl` + `lld-link`, so compile/link errors surface without a Windows round-trip. CI on `windows-2025` stays the authoritative build — this is a check loop, not a shipping artifact source, and does not touch `.github/workflows/*` or any client source.

- **Toolchain file** `cmake/toolchains/clang-cl-win32.cmake` — targets `i686-pc-windows-msvc`, MSVC CRT + Win32 SDK supplied by [xwin](https://github.com/Jake-Shadle/xwin), Ninja generator. Reuses the vendored `common/detours.lib` (i386 COFF) directly.
- **Driver script** `scripts/wsl-build.sh` — `./scripts/wsl-build.sh [REGION] [MAJOR] [MINOR] [TARGET]` (default `GMS 83 1`, all DLLs). Resolves the two Homebrew kegs (`llvm`, `lld`) and self-heals the one SDK lib case-alias xwin omits.
- **EH force-include shim** `cmake/toolchains/wsl-eh-forceinclude.h` — MSVC's frontend force-injects `<ehdata_forceinclude.h>` into every C++ TU (how `bypass/client_exception.cpp` sees `_CxxThrowException`/`_ThrowInfo`); clang-cl does not, so a `/FI` (CXX-only) shim supplies just those two symbols. CI never sees it.
- **Docs** — `docs/tasks/wsl-cross-compile/{design,plan,README}.md`.

Three WSL-only toolchain adaptations, all documented inline: `CMAKE_MT=/bin/true` (no `llvm-mt` in Homebrew; `/usr/bin/mt` is the Linux tape tool), MS `__asm` thunks compile under `-fms-extensions` (not `-fasm-blocks`), and the EH shim above.

## Test Plan

All six CI matrix configs verified to compile **and link** in WSL — 11 valid i386 PE DLLs each (10 edit DLLs + `proxy/ijl15.dll`; machine `0x14c`, DLL bit set):

- [x] GMS 83.1, 84.1, 87.1, 95.1, 111.1
- [x] JMS 185.1
- [x] `proxy/ijl15.cpp` inline-asm thunks compile
- [x] `bypass/client_exception.cpp` (RTTI/EH dispatch) compiles + links
- [x] No changes to CI workflows or client source; `build-wsl/` gitignored

> Note: this is a compile/link check only — it deliberately does **not** assert byte/ABI parity with the MSVC build, and the WSL-produced DLLs are not meant to be injected into the client. Running still requires a Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)