### PR TITLE
feat: socket connect fidelity — load-balancing + CLIENT_START_ERROR relay (task-007)

### DIFF
--- a/bypass/socket_hooks.cpp
+++ b/bypass/socket_hooks.cpp
@@ -29,14 +29,14 @@ typedef VOID(__thiscall* _CClientSocket__SendPacket_t)(CClientSocket* pThis, COu
 // at [+0x34], so total object >= 0x38; pad[0x3C] (total 0x40) is the conservative
 // cover.
 struct ClientFileStream {
-    void* vftable;     // [+0x00] -> C_FILE_STREAM_VFTABLE
-    char  pad[0x3C];   // [+0x04] conservative; covers the [+0x34] flag write
+    void* vftable;  // [+0x00] -> C_FILE_STREAM_VFTABLE
+    char pad[0x3C]; // [+0x04] conservative; covers the [+0x34] flag write
 };
 
-using FileStreamOpenFn  = int(__thiscall*)(void* self, const char* name, unsigned access,
-                                           unsigned share, int a3, unsigned disp, int a5, int a6);
-using FileStreamLenFn   = unsigned(__thiscall*)(void* self);
-using FileStreamReadFn  = int(__thiscall*)(void* self, void* dst, unsigned len);
+using FileStreamOpenFn = int(__thiscall*)(void* self, const char* name, unsigned access, unsigned share, int a3,
+                                          unsigned disp, int a5, int a6);
+using FileStreamLenFn = unsigned(__thiscall*)(void* self);
+using FileStreamReadFn = int(__thiscall*)(void* self, void* dst, unsigned len);
 using FileStreamCloseFn = void(__thiscall*)(void* self);
 
 // ---- OnConnect helpers (§4.2 refactor) ---------------------------------
@@ -135,10 +135,10 @@ INT __fastcall CClientSocket__OnConnect_Hook(CClientSocket* pThis, PVOID edx, in
             pThis->Close();
             if (pThis->m_ctxConnect.bLogin) {
                 Log("CClientSocket::OnConnect connect failed (login) -> RaiseTerminate(0x22000001)");
-                RaiseTerminate(0x22000001);   // CTerminateException, magic 570425345
+                RaiseTerminate(0x22000001); // CTerminateException, magic 570425345
             }
             Log("CClientSocket::OnConnect connect failed -> RaiseDisconnect(0x21000001)");
-            RaiseDisconnect(0x21000001);       // CDisconnectException, magic 553648129
+            RaiseDisconnect(0x21000001); // CDisconnectException, magic 553648129
         }
 
         // Advance the load-balancing cursor (GetNext returns the current node and
@@ -146,7 +146,7 @@ INT __fastcall CClientSocket__OnConnect_Hook(CClientSocket* pThis, PVOID edx, in
         auto* pos = reinterpret_cast<ZInetAddr*>(pThis->m_ctxConnect.posList);
         ZInetAddr* current = pThis->m_ctxConnect.lAddr.GetNext(&pos);
         pThis->m_ctxConnect.posList = reinterpret_cast<__POSITION*>(pos);
-        CClientSocket__Connect_Addr_Hook(pThis, edx, current);   // ZInetAddr : sockaddr_in
+        CClientSocket__Connect_Addr_Hook(pThis, edx, current); // ZInetAddr : sockaddr_in
         return 0;
     }
 
@@ -245,8 +245,19 @@ INT __fastcall CClientSocket__OnConnect_Hook(CClientSocket* pThis, PVOID edx, in
             ClientFileStream fs{};
             fs.vftable = reinterpret_cast<void*>(C_FILE_STREAM_VFTABLE);
 
+#if C_FILE_STREAM_OPEN_INLINE
+            // v95 has no standalone Open(): the stock OnConnect inlines CreateFileA and
+            // stores the handle at [+0x10], then ORs the open flag into the state dword
+            // at [+0x34]. Replicate that exact inline open, then drive the resolved
+            // GetLength/Read/Close by address (the existence guard above already made a
+            // routine missing file a no-op, mirroring the stock INVALID_HANDLE_VALUE throw).
+            *reinterpret_cast<HANDLE*>(reinterpret_cast<char*>(&fs) + 0x10) = CreateFileA(
+                fileName, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+            *reinterpret_cast<unsigned*>(reinterpret_cast<char*>(&fs) + 0x34) |= 1u;
+#else
             // Open(name, GENERIC_READ=0x80000000, share=128, 1, disp=0, 0, 0)
             reinterpret_cast<FileStreamOpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, 0x80000000u, 128, 1, 0, 0, 0);
+#endif
             unsigned len = reinterpret_cast<FileStreamLenFn>(C_FILE_STREAM_GET_LENGTH)(&fs);
 
             ZArray<char> report;

--- a/bypass/socket_hooks.cpp
+++ b/bypass/socket_hooks.cpp
@@ -112,16 +112,23 @@ INT __fastcall CClientSocket__OnConnect_Hook(CClientSocket* pThis, PVOID edx, in
     }
     if (!bSuccess) {
         if (!pThis->m_ctxConnect.posList) {
+            // Address list exhausted: close and raise the stock typed exception,
+            // which unwinds into the client WinMain handler (both [[noreturn]]).
             pThis->Close();
             if (pThis->m_ctxConnect.bLogin) {
-                Log("CClientSocket::OnConnect 570425345");
-                return 0;
+                Log("CClientSocket::OnConnect connect failed (login) -> RaiseTerminate(0x22000001)");
+                RaiseTerminate(0x22000001);   // CTerminateException, magic 570425345
             }
-            Log("CClientSocket::OnConnect 553648129");
-            return 0;
+            Log("CClientSocket::OnConnect connect failed -> RaiseDisconnect(0x21000001)");
+            RaiseDisconnect(0x21000001);       // CDisconnectException, magic 553648129
         }
-        // TODO do i really care to do the loadbalancing logic?
-        CClientSocket__Connect_Addr_Hook(pThis, edx, pThis->m_ctxConnect.lAddr.GetHeadPosition());
+
+        // Advance the load-balancing cursor (GetNext returns the current node and
+        // moves posList to node->m_pNext) and retry the *current* node's address.
+        auto* pos = reinterpret_cast<ZInetAddr*>(pThis->m_ctxConnect.posList);
+        ZInetAddr* current = pThis->m_ctxConnect.lAddr.GetNext(&pos);
+        pThis->m_ctxConnect.posList = reinterpret_cast<__POSITION*>(pos);
+        CClientSocket__Connect_Addr_Hook(pThis, edx, current);   // ZInetAddr : sockaddr_in
         return 0;
     }
 

--- a/bypass/socket_hooks.cpp
+++ b/bypass/socket_hooks.cpp
@@ -21,6 +21,24 @@ typedef INT(__thiscall* _CClientSocket__OnConnect_t)(CClientSocket* pThis, INT b
 typedef VOID(__thiscall* _CClientSocket__SendPacket_t)(CClientSocket* pThis, COutPacket* oPacket);
 #endif
 
+// ---- CLIENT_START_ERROR report-read mirror (§3) -------------------------
+// Thin stack mirror of the stock CFileStream object. Only vftable@[0] and
+// handle@[+0x10] are semantically meaningful to us, but the buffer MUST be at
+// least the full stock object size so Open/Read/Close do not write OOB.
+// `pad` is sized from the v84.1 stack frame (Task 3 / OQ-1): Open writes a dword
+// at [+0x34], so total object >= 0x38; pad[0x3C] (total 0x40) is the conservative
+// cover.
+struct ClientFileStream {
+    void* vftable;     // [+0x00] -> C_FILE_STREAM_VFTABLE
+    char  pad[0x3C];   // [+0x04] conservative; covers the [+0x34] flag write
+};
+
+using FileStreamOpenFn  = int(__thiscall*)(void* self, const char* name, unsigned access,
+                                           unsigned share, int a3, unsigned disp, int a5, int a6);
+using FileStreamLenFn   = unsigned(__thiscall*)(void* self);
+using FileStreamReadFn  = int(__thiscall*)(void* self, void* dst, unsigned len);
+using FileStreamCloseFn = void(__thiscall*)(void* self);
+
 // ---- OnConnect helpers (§4.2 refactor) ---------------------------------
 namespace {
 
@@ -215,9 +233,41 @@ INT __fastcall CClientSocket__OnConnect_Hook(CClientSocket* pThis, PVOID edx, in
     }
 
     if (pThis->m_ctxConnect.bLogin) {
-        Log("CClientSocket::OnConnect should be sending [%d]", CLIENT_START_ERROR);
-        // TODO relay CLIENT_START_ERROR
+        Log("CClientSocket::OnConnect relaying CLIENT_START_ERROR [%d]", CLIENT_START_ERROR);
+#if C_FILE_STREAM_RESOLVED
         char* fileName = CWvsApp::GetExceptionFileName();
+
+        // OQ-throw (b): the stock Open() throws ZException on a missing file and
+        // the throw escapes OnConnect. Pre-check existence so a routine missing
+        // report is a silent no-op (no packet, no exception) per FR-11. Only the
+        // (0 < len < 0x2000) guard below is insufficient — the throw is earlier.
+        if (fileName && GetFileAttributesA(fileName) != INVALID_FILE_ATTRIBUTES) {
+            ClientFileStream fs{};
+            fs.vftable = reinterpret_cast<void*>(C_FILE_STREAM_VFTABLE);
+
+            // Open(name, GENERIC_READ=0x80000000, share=128, 1, disp=0, 0, 0)
+            reinterpret_cast<FileStreamOpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, 0x80000000u, 128, 1, 0, 0, 0);
+            unsigned len = reinterpret_cast<FileStreamLenFn>(C_FILE_STREAM_GET_LENGTH)(&fs);
+
+            ZArray<char> report;
+            if (len && len < 0x2000) {
+                char* dst = report.SetSize(len);
+                reinterpret_cast<FileStreamReadFn>(C_FILE_STREAM_READ)(&fs, dst, len);
+            }
+            reinterpret_cast<FileStreamCloseFn>(C_FILE_STREAM_CLOSE)(&fs);
+
+            if (report.GetCount()) {
+                COutPacket pkt(CLIENT_START_ERROR);
+                pkt.Encode2(static_cast<unsigned short>(report.GetCount()));
+                pkt.EncodeBuffer(report.GetData(), report.GetCount());
+                CClientSocket::GetInstance()->SendPacket(&pkt);
+            }
+            // ZArray<char> report frees itself at scope exit; fs is a stack object,
+            // its handle released by Close().
+        }
+#else
+        Log("CClientSocket::OnConnect CLIENT_START_ERROR relay gated off for this version");
+#endif
     } else {
         Log("CClientSocket::OnConnect accountId=[%d], worldId=[%d], channelId=[%d], characterId=[%d]",
             CWvsContext::GetInstance()->m_dwAccountId, CWvsContext::GetInstance()->m_nWorldID,

--- a/common/ZArray.h
+++ b/common/ZArray.h
@@ -275,6 +275,27 @@ public:
 	}
 
 	/// <summary>
+	/// Allocate exactly n elements, set the count header to n, and return the
+	/// data pointer. Models the stock report-buffer resize (sub_49BBBE) for a
+	/// fresh read into an empty array: Alloc() frees any prior block, allocates
+	/// n*sizeof(T)+sizeof(PVOID), and writes the count header = n.
+	/// </summary>
+	T* SetSize(size_t n)
+	{
+		this->Alloc(n);
+		return this->a;
+	}
+
+	/// <summary>
+	/// Raw pointer to element 0 (base of the allocation, after the count header).
+	/// Intention-revealing alias of GetTailPosition() for buffer call sites.
+	/// </summary>
+	T* GetData()
+	{
+		return this->a;
+	}
+
+	/// <summary>
 	/// Removes all items from the array and calls their destructors.
 	/// </summary>
 	void RemoveAll()

--- a/common/ZArray.h
+++ b/common/ZArray.h
@@ -275,27 +275,6 @@ public:
 	}
 
 	/// <summary>
-	/// Allocate exactly n elements, set the count header to n, and return the
-	/// data pointer. Models the stock report-buffer resize (sub_49BBBE) for a
-	/// fresh read into an empty array: Alloc() frees any prior block, allocates
-	/// n*sizeof(T)+sizeof(PVOID), and writes the count header = n.
-	/// </summary>
-	T* SetSize(size_t n)
-	{
-		this->Alloc(n);
-		return this->a;
-	}
-
-	/// <summary>
-	/// Raw pointer to element 0 (base of the allocation, after the count header).
-	/// Intention-revealing alias of GetTailPosition() for buffer call sites.
-	/// </summary>
-	T* GetData()
-	{
-		return this->a;
-	}
-
-	/// <summary>
 	/// Removes all items from the array and calls their destructors.
 	/// </summary>
 	void RemoveAll()
@@ -336,6 +315,25 @@ public:
         /* We take index 1 because index zero is the array item count */
         pAlloc += 1;
         this->a = reinterpret_cast<T*>(pAlloc);
+    }
+
+    /// <summary>
+    /// Allocate exactly n elements, set the count header to n, and return the
+    /// data pointer. Models the stock report-buffer resize (sub_49BBBE) for a
+    /// fresh read into an empty array: Alloc() frees any prior block, allocates
+    /// n*sizeof(T)+sizeof(PVOID), and writes the count header = n.
+    /// </summary>
+    T* SetSize(size_t n) {
+        this->Alloc(n);
+        return this->a;
+    }
+
+    /// <summary>
+    /// Raw pointer to element 0 (base of the allocation, after the count header).
+    /// Intention-revealing alias of GetTailPosition() for buffer call sites.
+    /// </summary>
+    T* GetData() {
+        return this->a;
     }
 
 private:

--- a/docs/tasks/task-007-socket-connect-fidelity/build-matrix.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/build-matrix.md
@@ -1,0 +1,32 @@
+# Build Matrix — Socket Connect Fidelity (task-007)
+
+Full acceptance matrix via `scripts/wsl-build.sh <REGION> <MAJOR> <MINOR>` (clang-cl + xwin,
+WSL). Each row built with a clean `build-wsl/` dir. All five exit 0 with the proxy + every
+edit DLL linked.
+
+| Region/Version | Build | `C_FILE_STREAM_RESOLVED` | Relay path compiled | Notes |
+|---|---|---|---|---|
+| GMS 83 1 | ✅ exit 0 | 0 | `#else` Log-only no-op | OnConnect CFG-obfuscated → gated off |
+| GMS 84 1 | ✅ exit 0 | 1 | resolved relay | anchor version; addresses audited |
+| GMS 87 1 | ✅ exit 0 | 1 | resolved relay | addresses audited |
+| GMS 111 1 | ✅ exit 0 | 0 | `#else` Log-only no-op | redesigned non-vtable stream class → gated off |
+| JMS 185 1 | ✅ exit 0 | 1 | resolved relay | major 185 ≥ 95 → also exercises the gated SendPacket-hook typedef; opcode corrected 0x15→0x0F |
+
+## New-warning scan (touched files only)
+
+`grep -iE "warning|error"` over all five build logs, filtered to `socket_hooks.cpp` /
+`ZArray.h`: **no warnings on any edited region.** The only `socket_hooks.cpp` warnings present
+are pre-existing and live in the hook-install/Detours section (lines ~319, 363–376):
+`WSAAsyncSelect` deprecation and `-Wmicrosoft-cast` (function-pointer ↔ object-pointer) — both
+predate task-007 and were not introduced or moved by this work. `common/ZArray.h` produced no
+warnings in any build.
+
+## Mapping to the task's edits
+
+- `common/ZArray.h` — `SetSize`/`GetData` (Task 1): clean in all 5.
+- `bypass/socket_hooks.cpp` `!bSuccess` load-balancing (Task 2): clean, unconditional, all 5.
+- `bypass/socket_hooks.cpp` `ClientFileStream` mirror + relay (Task 5): compiles the resolved
+  path on GMS 84/87 + JMS 185, the `#else` no-op on GMS 83/111.
+- `memory_maps/*` + `include/memory_map.h.in` (Task 4): every version resolves all six
+  `C_FILE_STREAM_*` keys (GenerateMemoryMap validation passes — a missing/empty key is a
+  configure-time FATAL_ERROR, so a clean configure is itself the proof).

--- a/docs/tasks/task-007-socket-connect-fidelity/build-matrix.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/build-matrix.md
@@ -7,10 +7,17 @@ edit DLL linked.
 | Region/Version | Build | `C_FILE_STREAM_RESOLVED` | Relay path compiled | Notes |
 |---|---|---|---|---|
 | GMS 83 1 | ✅ exit 0 | 0 | `#else` Log-only no-op | OnConnect CFG-obfuscated → gated off |
-| GMS 84 1 | ✅ exit 0 | 1 | resolved relay | anchor version; addresses audited |
-| GMS 87 1 | ✅ exit 0 | 1 | resolved relay | addresses audited |
+| GMS 84 1 | ✅ exit 0 | 1 | resolved relay (standalone Open) | anchor version; addresses audited |
+| GMS 87 1 | ✅ exit 0 | 1 | resolved relay (standalone Open) | addresses audited |
+| GMS 95 1 | ✅ exit 0 | 1 | resolved relay (inline open) | `C_FILE_STREAM_OPEN_INLINE 1`; CI builds this version |
 | GMS 111 1 | ✅ exit 0 | 0 | `#else` Log-only no-op | redesigned non-vtable stream class → gated off |
-| JMS 185 1 | ✅ exit 0 | 1 | resolved relay | major 185 ≥ 95 → also exercises the gated SendPacket-hook typedef; opcode corrected 0x15→0x0F |
+| JMS 185 1 | ✅ exit 0 | 1 | resolved relay (standalone Open) | major 185 ≥ 95 → also exercises the gated SendPacket-hook typedef; opcode corrected 0x15→0x0F |
+
+> **GMS v95.1 was added to this matrix after the first CI run** revealed CI builds 6 versions
+> (the 5 PRD targets + the v95 PDB reference). v95 inlines `CreateFileA` in `OnConnect`, so it
+> uses the new `C_FILE_STREAM_OPEN_INLINE 1` path (relay replicates the inline open, drives the
+> resolved `ZFileStream` GetLength/Read/Close). The other five versions set
+> `C_FILE_STREAM_OPEN_INLINE 0`. All 6 build clean via `scripts/wsl-build.sh`.
 
 ## New-warning scan (touched files only)
 

--- a/docs/tasks/task-007-socket-connect-fidelity/context.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/context.md
@@ -1,0 +1,102 @@
+# Context — Socket Connect Fidelity (task-007)
+
+Quick reference for agents executing `plan.md`. Source of truth is `prd.md`, `design.md`,
+`hook-design.md`, `memory-map.md`.
+
+## What's being changed
+
+Two in-place rewrites inside one hook — `CClientSocket__OnConnect_Hook` in
+`bypass/socket_hooks.cpp`. No new Detours installs, no new DLL edit, no INI surface.
+
+1. **Load balancing** (`!bSuccess` block, `socket_hooks.cpp:113-126`) — advance the
+   `posList` cursor via `ZList<ZInetAddr>::GetNext`, retry the current node; on exhaustion
+   `Close()` + `RaiseTerminate(0x22000001)` (login) / `RaiseDisconnect(0x21000001)`.
+2. **CLIENT_START_ERROR relay** (`bSuccess && bLogin` block, `socket_hooks.cpp:210-213`) —
+   read the exception report via the stock `CFileStream` helpers into a `ZArray<char>`,
+   send `COutPacket(CLIENT_START_ERROR)` + `Encode2(len)` + `EncodeBuffer(buf,len)`.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `bypass/socket_hooks.cpp` | the hook; both rewrites + `ClientFileStream` mirror + fn-ptr typedefs |
+| `common/ZArray.h` | add `SetSize(size_t)` / `GetData()` (report buffer) |
+| `common/ZList.h` | `GetNext(T** pos)` @ `:333` — the cursor-advance idiom (already exists) |
+| `common/ZInetAddr.h` | `struct ZInetAddr : sockaddr_in` — base-cast to `const sockaddr_in*` |
+| `common/CClientSocket.h` | `CONNECTCONTEXT { ZList<ZInetAddr> lAddr; __POSITION* posList; int bLogin; }` |
+| `common/COutPacket.h` | `COutPacket(INT)`, `Encode2(unsigned short)`, `EncodeBuffer(const void*, unsigned)` |
+| `common/CWvsApp.cpp:92` | `CWvsApp::GetExceptionFileName()` — `static char* __cdecl`, returns report path |
+| `bypass/client_exception.h` | `[[noreturn]] RaiseTerminate(int)` / `RaiseDisconnect(int)` (impl in `.cpp`) |
+| `include/memory_map.h.in` | add 6 `@KEY@` defines (template) |
+| `memory_maps/{GMS,JMS}/v*_*.cmake` | per-version `set()` for the 6 keys |
+| `cmake/GenerateMemoryMap.cmake` | validates every `@KEY@` is defined + non-empty per version |
+
+## Region/version matrix (acceptance)
+
+`GMS 83 1`, `GMS 84 1`, `GMS 87 1`, `GMS 111 1`, `JMS 185 1`.
+Build: `scripts/wsl-build.sh <REGION> <MAJOR> <MINOR>` (clang-cl + xwin; exit 0 = clean).
+
+## Hook addresses (GMS v84.1, loaded IDB `GMS_v84.1_U_DEVM`)
+
+`CClientSocket::OnConnect` @ `0x00499DCD`. File-stream helper set (known v84.1):
+
+| Symbol | v84.1 | Meaning |
+|---|---|---|
+| `C_FILE_STREAM_OPEN` | `0x0049A615` | `__thiscall Open(name,access,share,…)` → `CreateFileA`; handle → `[this+0x10]` |
+| `C_FILE_STREAM_GET_LENGTH` | `0x0049A79E` | `__thiscall GetLength()` |
+| `C_FILE_STREAM_READ` | `0x0049A8C9` | `__thiscall Read(dst,len)` |
+| `C_FILE_STREAM_CLOSE` | `0x0049A5B7` | `__thiscall Close()`/dtor |
+| `C_FILE_STREAM_VFTABLE` | `0x00B437BC` | stream object vtable |
+
+v83.1 / v87.1 / v111.1 / JMS v185.1 = **resolve in Task 3** (recipe in `memory-map.md`).
+Already mapped (do not re-add): `CLIENT_START_ERROR` (`0x19` v83/84/87, `0x2F` v111, `0x15`
+JMS185), `C_WVS_APP_GET_EXCEPTION_FILE_NAME`, `C_TI_TERMINATE_EXCEPTION`,
+`C_TI_DISCONNECT_EXCEPTION`, `C_CLIENT_SOCKET_ON_CONNECT`.
+
+## Magic numbers
+
+| Hex | Decimal | Exception |
+|---|---|---|
+| `0x22000001` | 570425345 | `CTerminateException` (login exhaustion) |
+| `0x21000001` | 553648129 | `CDisconnectException` (non-login exhaustion) |
+| `0x22000007` | 570425351 | `CTerminateException` (version/patch ladder — already handled, unchanged) |
+
+## Open questions resolved in Task 3 (disassembly, not preference)
+
+- **OQ-1 object size:** `ClientFileStream` total must cover the highest offset the four
+  methods write. `Open` writes a dword at `[+0x34]` → object ≥ `0x38`. **Design's `pad[0x30]`
+  (total `0x34`) is too small by 4 bytes.** Use `pad[0x3C]` (total `0x40`) unless Task 3 finds
+  a larger footprint; size `pad = total − 4`.
+- **OQ-throw missing-file:** confirm whether `Open` throws on `INVALID_HANDLE_VALUE` for a
+  routine missing report and whether `OnConnect` catches it. FR-11 requires missing/empty →
+  no packet, no exception. Guard the read path only if the disassembly shows `Open` can throw
+  on a normal missing file.
+- **OQ-2 (resolved):** model `SetSize`/`GetData` in `ZArray.h`; no `C_ZARRAY_BYTE_SETSIZE`
+  symbol.
+
+## Gating mechanism
+
+New `C_FILE_STREAM_RESOLVED` (1/0) per version. The relay body is wrapped in
+`#if C_FILE_STREAM_RESOLVED … #else Log-only no-op #endif`. A version whose helpers can't be
+resolved gets `0x0` placeholder addresses + `C_FILE_STREAM_RESOLVED 0` so the build stays
+green and the placeholder is never called. Load-balancing (Task 2) is unconditional — it
+needs no new symbols.
+
+## Must NOT change (hook-design.md §3)
+
+- Top guard `if (!pThis->m_ctxConnect.lAddr.GetCount()) return 0;` (`socket_hooks.cpp:110-112`).
+- `decode_handshake` and the version/patch ladder (`RaiseTerminate(0x22000007)`/`RaisePatch()`).
+- The non-login `PLAYER_LOGGED_IN` send branch (`socket_hooks.cpp:214-238`).
+- The `BUILD_MAJOR_VERSION >= 95` `SendPacket` rewrite + its `#if` gate.
+
+## Wire format (atlas-login parity)
+
+`serverbound.StartError.Decode`: `length = ReadUint16(); bytes = ReadBytes(length)`.
+`Encode2` = little-endian u16, `EncodeBuffer` = raw bytes → exact match. Handled by
+`StartErrorHandleFunc` in `atlas/services/atlas-login/atlas.com/login/socket/handler/start_error.go`.
+
+## Dependencies / ordering
+
+Task 0 (branch) → 1 (ZArray, independent) → 2 (load-balancing, independent) →
+3 (IDA resolve, gates 4+5) → 4 (memory-map plumbing) → 5 (relay, needs 1+3+4) →
+6 (build matrix) → 7 (runtime). Commit after each task; never commit to `main`.

--- a/docs/tasks/task-007-socket-connect-fidelity/design.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/design.md
@@ -1,0 +1,321 @@
+# Design — Socket Connect Fidelity (Load Balancing & CLIENT_START_ERROR)
+
+Status: Draft for review
+Created: 2026-06-12
+Inputs: `prd.md`, `hook-design.md`, `memory-map.md` (same folder)
+
+---
+
+## 1. Scope & Decisions
+
+This task rewrites two regions **inside** the existing `CClientSocket__OnConnect_Hook`
+in `bypass/socket_hooks.cpp`. No new Detours installs, no new DLL edit, no INI surface.
+
+Two design forks were resolved during brainstorming:
+
+| Fork | Decision | Consequence |
+|---|---|---|
+| How to read the exception report file | **Reconstruct the client `CFileStream` stack object and drive `Open/GetLength/Read/Close` by mapped address** (faithful to stock; matches this repo's RE-fidelity ethos) | Adds 5 new per-version memory-map symbols; OQ-1 (object size) resolved from disassembly |
+| How to model the report buffer | **Add `SetSize`/`GetData` to `common/ZArray.h`** and read into a `ZArray<char>` as the stock does | No `C_ZARRAY_BYTE_SETSIZE` symbol needed (modeled in the template); small shared-header surface added |
+
+The **load-balancing** rewrite needs no new map symbols — it uses our existing
+`ZList<ZInetAddr>::GetNext` and the existing `RaiseTerminate`/`RaiseDisconnect` helpers.
+
+Everything in PRD §"Things that must NOT change" / `hook-design.md` §3 is preserved:
+the top guard `if (!lAddr.GetCount()) return 0;`, the handshake decode, the version/patch
+ladder, the non-login `PLAYER_LOGGED_IN` branch, and the `BUILD_MAJOR_VERSION >= 95`
+`SendPacket` rewrite + its `#if` gate.
+
+---
+
+## 2. Component A — Load-balancing rewrite (`!bSuccess`)
+
+Replaces the current dead code at `socket_hooks.cpp:113-126` (the two `Log(...) return 0`
+stubs and the `GetHeadPosition()` re-pass marked `// TODO do i really care...`).
+
+### Behavior
+
+```cpp
+if (!bSuccess) {
+    if (!pThis->m_ctxConnect.posList) {            // list exhausted
+        pThis->Close();
+        if (pThis->m_ctxConnect.bLogin) {
+            Log("CClientSocket::OnConnect connect failed (login) -> RaiseTerminate(0x22000001)");
+            RaiseTerminate(0x22000001);            // [[noreturn]] CTerminateException, magic 570425345
+        }
+        Log("CClientSocket::OnConnect connect failed -> RaiseDisconnect(0x21000001)");
+        RaiseDisconnect(0x21000001);               // [[noreturn]] CDisconnectException, magic 553648129
+    }
+
+    // Advance the cursor; retry the *current* (pre-advance) node's address.
+    ZInetAddr* pos = reinterpret_cast<ZInetAddr*>(pThis->m_ctxConnect.posList);
+    ZInetAddr* current = pThis->m_ctxConnect.lAddr.GetNext(&pos);
+    pThis->m_ctxConnect.posList = reinterpret_cast<__POSITION*>(pos);
+    CClientSocket__Connect_Addr_Hook(pThis, edx, current);   // ZInetAddr : sockaddr_in (base cast)
+    return 0;
+}
+```
+
+### Why this is correct / low-risk
+
+- `ZList<ZInetAddr>::GetNext(T** pos)` already exists (`common/ZList.h`) and implements the
+  exact stock idiom: it returns the current node and advances `*pos` to `node->m_pNext`
+  (via `CastNode`, which subtracts 16 — matching the disassembly's `posList-16+4` → `m_pNext`,
+  `+16` → wrapped `ZInetAddr*`). We do **not** re-derive the pointer math by hand.
+- `ZInetAddr` is declared `struct ZInetAddr : sockaddr_in`, so passing a node where the hook
+  expects `const sockaddr_in*` is a plain base-class conversion — no `reinterpret_cast` on the
+  argument (mirrors `Connect_Ctx_Hook`, which passes `&pThis->m_addr`).
+- The `posList ↔ __POSITION*` casts mirror the existing
+  `reinterpret_cast<__POSITION*>(lAddr.GetHeadPosition())` already in `Connect_Ctx_Hook`.
+- `RaiseTerminate`/`RaiseDisconnect` are `[[noreturn]]` (`bypass/client_exception.cpp`) and
+  unwind into the stock WinMain handler via the client's own `_ThrowInfo`. **No trailing
+  `return`** after them — they do not return, and the exhaustion branch therefore cannot fall
+  through into the success path below.
+
+### Magic-number cross-check
+
+| Constant | Hex | Exception |
+|---|---|---|
+| 570425345 | `0x22000001` | `CTerminateException` (login exhaustion) |
+| 553648129 | `0x21000001` | `CDisconnectException` (non-login exhaustion) |
+| 570425351 | `0x22000007` | `CTerminateException` (version mismatch — already handled, unchanged) |
+
+---
+
+## 3. Component B — `CLIENT_START_ERROR` relay (`bSuccess && bLogin`)
+
+Replaces the `bLogin` stub at `socket_hooks.cpp:210-213` (the `// TODO relay
+CLIENT_START_ERROR` and the dangling `GetExceptionFileName()` whose result is dropped). The
+non-login `else` branch (`PLAYER_LOGGED_IN`) is unchanged.
+
+### Data flow
+
+```
+CWvsApp::GetExceptionFileName()  ->  fileName
+        │
+        ▼
+ClientFileStream fs;  fs.vftable = C_FILE_STREAM_VFTABLE
+        │  Open(fileName, GENERIC_READ, share=128, 1, 0, 0, 0)   [C_FILE_STREAM_OPEN]
+        ▼
+len = GetLength()                                                [C_FILE_STREAM_GET_LENGTH]
+        │  guard: 0 < len < 0x2000
+        ▼
+report.SetSize(len) -> dst ;  Read(dst, len)                    [ZArray<char> ; C_FILE_STREAM_READ]
+        │
+        ▼
+Close()                                                          [C_FILE_STREAM_CLOSE]
+        │  if report.GetCount():
+        ▼
+COutPacket(CLIENT_START_ERROR) . Encode2(len) . EncodeBuffer(report.GetData(), len)
+        │
+        ▼
+CClientSocket::GetInstance()->SendPacket(&pkt)
+```
+
+### Implementation
+
+```cpp
+if (pThis->m_ctxConnect.bLogin) {
+    Log("CClientSocket::OnConnect relaying CLIENT_START_ERROR [%d]", CLIENT_START_ERROR);
+    char* fileName = CWvsApp::GetExceptionFileName();
+
+    ClientFileStream fs{};
+    fs.vftable = reinterpret_cast<void*>(C_FILE_STREAM_VFTABLE);
+
+    using OpenFn  = int(__thiscall*)(void*, const char*, unsigned, unsigned, int, unsigned, int, int);
+    using LenFn   = unsigned(__thiscall*)(void*);
+    using ReadFn  = int(__thiscall*)(void*, void*, unsigned);
+    using CloseFn = void(__thiscall*)(void*);
+
+    reinterpret_cast<OpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, 0x80000000u, 128, 1, 0, 0, 0);
+    unsigned len = reinterpret_cast<LenFn>(C_FILE_STREAM_GET_LENGTH)(&fs);
+
+    ZArray<char> report;
+    if (len && len < 0x2000) {
+        char* dst = report.SetSize(len);
+        reinterpret_cast<ReadFn>(C_FILE_STREAM_READ)(&fs, dst, len);
+    }
+    reinterpret_cast<CloseFn>(C_FILE_STREAM_CLOSE)(&fs);
+
+    if (report.GetCount()) {
+        COutPacket pkt(CLIENT_START_ERROR);
+        pkt.Encode2(static_cast<unsigned short>(report.GetCount()));
+        pkt.EncodeBuffer(report.GetData(), report.GetCount());
+        CClientSocket::GetInstance()->SendPacket(&pkt);
+    }
+} else {
+    /* existing PLAYER_LOGGED_IN branch — unchanged */
+}
+```
+
+### `ClientFileStream` mirror (OQ-1)
+
+```cpp
+struct ClientFileStream {
+    void* vftable;     // [+0x00] -> C_FILE_STREAM_VFTABLE
+    char  pad[0x30];   // [+0x04] conservative; size from the v84.1 stack frame
+};
+```
+
+Only `vftable@[0]` and `handle@[+0x10]` are semantically meaningful to us, but the buffer
+**must** be at least the full stock object size so `Open`/`Read`/`Close` do not write out of
+bounds (`Open` zeroes `[+8]`,`[+0xC]` and ORs flags into `[+0x34]`). **Resolution (OQ-1):**
+read the exact stack footprint of the stream local in v84.1 `CClientSocket::OnConnect`
+(the decompile shows a `v34[12]` 0x30 region; confirm the highest offset any of the four
+methods touch) and size `pad` to cover it, rounding up. This is the same "size a local buffer
+conservatively from disassembly" pattern `RaisePatch` uses for `CPatchException` (2048-byte
+buffer ≥ the 1288-byte object). Anchor the final size to disassembly evidence, not a guess.
+
+### Resource hygiene & error tolerance
+
+- `ClientFileStream` is a stack object; `Close()` releases the OS handle. There is no heap
+  stream to free. `ZArray<char> report` frees itself in its destructor at scope exit
+  (`RemoveAll` → `Z_ARRAY_REMOVE_ALL`).
+- Missing / locked / zero-byte file: stock `Open` throws `ZException` on
+  `INVALID_HANDLE_VALUE`. **Open question for implementation (see §7):** confirm whether the
+  stock `OnConnect` swallows that throw or relies on the outer handler; our reimplementation
+  must match — if stock tolerates a missing file by sending nothing (the PRD's stated
+  contract, FR-11), we must not let an `Open` throw escape as a crash. Default: if the file is
+  absent, `GetLength` returns 0 and the `(0,0x2000)` guard skips the read, `report` stays
+  empty, and nothing is sent — no exception raised (matches stock `if (buf && len)`).
+- The `(0 < len < 0x2000)` guard bounds the allocation and the wire payload identically to
+  stock.
+
+### Wire-format parity (FR-13)
+
+`Encode2` is little-endian u16; `EncodeBuffer` appends raw bytes. atlas-login
+`serverbound.StartError.Decode` reads `ReadUint16 length` then `ReadBytes(length)` and
+dispatches to `StartErrorHandleFunc`
+(`atlas/services/atlas-login/.../socket/handler/start_error.go`). Exact match.
+
+---
+
+## 4. `common/ZArray.h` — `SetSize` / `GetData`
+
+The stock report buffer is a `ZArray<char>` resized by `sub_49BBBE`. We model that in the
+template rather than calling it by address.
+
+```cpp
+// Allocate exactly n elements, set the count header to n, return the data pointer.
+T* SetSize(size_t n) {
+    this->Alloc(n);     // existing: RemoveAll + alloc (n*sizeof(T)+sizeof(PVOID)); head = n
+    return this->a;
+}
+
+// Raw pointer to element 0 (base of the allocation, after the count header).
+T* GetData() {
+    return this->a;
+}
+```
+
+- `Alloc(size_t)` already exists and does exactly "free old, allocate `n`, write count header
+  `= n`, point `a` at the first element." For a fresh report read (no prior contents to
+  preserve) this is the correct semantics. **Verify against `sub_49BBBE`'s disassembly during
+  implementation:** if the stock helper preserves contents or uses a doubling/Realloc path,
+  adjust `SetSize` accordingly; for a single read into an empty array the observable result
+  (a buffer of exactly `len` bytes, count `= len`) is the same.
+- `GetData()` returns `this->a` — the same base `GetTailPosition()` already returns;
+  `GetData` is added as the intention-revealing name the call site uses.
+- These are additive, non-virtual, header-only methods on an existing template. No existing
+  caller changes. Risk to other TUs using `ZArray<T>` is nil (no signature/layout change).
+
+---
+
+## 5. Memory-map additions
+
+New per-version symbols (file-stream helper set). Added to each
+`memory_maps/<REGION>/v<MAJOR>_<MINOR>.cmake` and surfaced in `include/memory_map.h.in`.
+`C_ZARRAY_BYTE_SETSIZE` is **not** added (modeled in `ZArray.h` per §4).
+
+| Symbol | Meaning | GMS v84.1 |
+|---|---|---|
+| `C_FILE_STREAM_OPEN` | `__thiscall Open(name,access,share,…)` → `CreateFileA` | `0x0049A615` |
+| `C_FILE_STREAM_GET_LENGTH` | `__thiscall GetLength()` → size | `0x0049A79E` |
+| `C_FILE_STREAM_READ` | `__thiscall Read(dst,len)` | `0x0049A8C9` |
+| `C_FILE_STREAM_CLOSE` | `__thiscall Close()` / dtor | `0x0049A5B7` |
+| `C_FILE_STREAM_VFTABLE` | stream object vtable | `0x00B437BC` |
+
+Already present (verify, do not re-add): `CLIENT_START_ERROR`,
+`C_WVS_APP_GET_EXCEPTION_FILE_NAME`, `C_TI_TERMINATE_EXCEPTION`,
+`C_TI_DISCONNECT_EXCEPTION`, `C_CLIENT_SOCKET_ON_CONNECT`.
+
+Per-IDB resolution recipe (from `memory-map.md` §"Resolution recipe"):
+1. `get_metadata` to confirm the loaded IDB version (per the verify-IDA-target rule).
+2. Decompile that version's `CClientSocket::OnConnect`; find the `bLogin` branch.
+3. The call after `GetExceptionFileName()` taking `0x80000000` (GENERIC_READ) is
+   `C_FILE_STREAM_OPEN`; the vtable assigned to the stack object just before it is
+   `C_FILE_STREAM_VFTABLE`; subsequent length/read/close calls map in order.
+4. Confirm the `COutPacket` ctor argument equals that version's `CLIENT_START_ERROR` opcode
+   (already mapped: `0x19` v83/v84/v87, `0x1A` v95, `0x2F` v111, `0x15` JMS185).
+
+---
+
+## 6. Per-version gating strategy
+
+Targets: GMS v83.1, v84.1, v87.1, v111.1, JMS v185.1 (must compile + link, per acceptance).
+
+- The five `C_FILE_STREAM_*` symbols are resolved per version from each IDB. v84.1 values are
+  known; the rest are `TBD` in `memory-map.md` and resolved during implementation.
+- **If a version cannot faithfully resolve the stream helpers** (helper inlined, vtable
+  ambiguous, or object impractical to reconstruct): gate that version's relay body off behind
+  a documented `#if`, leaving the `bLogin` branch as a `Log(...)`-only no-op for that version,
+  and mark the symbol row `N/A` with a one-line reason in `memory-map.md`. The build must
+  still succeed and the load-balancing fix (which needs no new symbols) still applies. This is
+  pre-approved by PRD §7.
+- The load-balancing rewrite (§2) is **unconditional** across all versions — it depends only
+  on `ZList`/exception helpers that already exist for every configured version.
+
+---
+
+## 7. Open questions carried into implementation
+
+These are disassembly-resolved, not user-preference forks; listed so the plan tracks them.
+
+- **OQ-1 — `ClientFileStream` object size.** Resolve the exact stack footprint from v84.1
+  `CClientSocket::OnConnect`; size `pad` conservatively to cover the highest offset any of the
+  four methods writes (`[+0x34]` flags seen so far). Anchor to disassembly evidence.
+- **OQ-Open-throw — missing-file behavior.** Confirm from the v84.1 disassembly whether stock
+  `CFileStream::Open` throwing on a missing report is caught locally or escapes. Reconcile
+  with FR-11 ("missing/empty → no packet, no exception"). If `Open` can throw on a normal
+  missing-file case, the design must guard the path (e.g. pre-check existence, or confirm
+  `GetLength`-returns-0 path is reached without a throw) so a routine missing report never
+  crashes the client.
+- **Per-version `C_FILE_STREAM_*` addresses** for v83.1, v87.1, v111.1, JMS v185.1 — resolve
+  per the §5 recipe; gate off per §6 if any version can't be resolved faithfully.
+
+(OQ-2 from the PRD — ZArray reuse vs call-by-address — is **resolved**: model `SetSize`/
+`GetData` in `ZArray.h` per §4; no `C_ZARRAY_BYTE_SETSIZE` symbol.)
+
+---
+
+## 8. Testing & verification
+
+Per the repo's build/verify conventions (`scripts/wsl-build.sh`) and PRD §10 acceptance:
+
+1. **Build matrix.** `scripts/wsl-build.sh` compiles + links all DLLs for GMS v83.1, v84.1,
+   v87.1, v111.1, and JMS v185.1 with no new warnings in `bypass/socket_hooks.cpp` or
+   `common/ZArray.h`.
+2. **Load-balancing runtime (GMS v84.1, loaded IDB).** Force a bad login address list so the
+   first node fails: confirm the cursor advances node-by-node and, on exhaustion, the client
+   `Close()`s and shows the stock "cannot connect" failure (terminate path) rather than
+   looping on the first address.
+3. **`CLIENT_START_ERROR` runtime (GMS v84.1).** Seed a non-empty exception report at the
+   `GetExceptionFileName()` path, connect to login, and observe atlas-login's
+   `StartErrorHandleFunc` receive a `CLIENT_START_ERROR` whose payload equals the file bytes.
+4. **Missing-report tolerance.** With no report file present, confirm login proceeds with no
+   `CLIENT_START_ERROR` sent and no exception/crash.
+5. **No happy-path regression.** Non-login game socket still sends `PLAYER_LOGGED_IN`; the
+   version/patch ladder still raises correctly.
+
+---
+
+## 9. Files touched (summary)
+
+| File | Change |
+|---|---|
+| `bypass/socket_hooks.cpp` | Rewrite `!bSuccess` load-balancing block (§2) and `bLogin` relay block (§3); add the `ClientFileStream` mirror struct + fn-ptr typedefs |
+| `common/ZArray.h` | Add `SetSize(size_t)` and `GetData()` (§4) |
+| `memory_maps/GMS/v83_1.cmake`, `v84_1.cmake`, `v87_1.cmake`, `v111_1.cmake`, `memory_maps/JMS/v185_1.cmake` | Add `C_FILE_STREAM_{OPEN,GET_LENGTH,READ,CLOSE,VFTABLE}` (§5) |
+| `include/memory_map.h.in` | Surface the five new `C_FILE_STREAM_*` defines |
+
+No new files. No new DLL edit. No INI changes.

--- a/docs/tasks/task-007-socket-connect-fidelity/hook-design.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/hook-design.md
@@ -1,0 +1,173 @@
+# Hook Design — Socket Connect Fidelity
+
+Scope: rewrite two regions inside `CClientSocket__OnConnect_Hook` (`bypass/socket_hooks.cpp`).
+No new Detours installs. All addresses below are **GMS v84.1** (loaded IDB
+`GMS_v84.1_U_DEVM`); `CClientSocket::OnConnect` @ `0x00499DCD`.
+
+---
+
+## 1. Load balancing — `!bSuccess` branch
+
+### Stock behavior (decompiled)
+```c
+if (!bSuccess) {
+    if (!this->m_ctxConnect.posList) {            // [this+32] == NULL  -> list exhausted
+        CClientSocket::Close(this);
+        if (this->m_ctxConnect.bLogin)            // [this+36]
+            throw CTerminateException(0x22000001);  // magic 570425345
+        throw CDisconnectException(0x21000001);     // magic 553648129
+    }
+    // posList != NULL: GetNext(&posList), Connect(currentNode)
+    next = posList ? *(posList - 16 + 4) : *(int*)4;   // node->m_pNext
+    saved = posList;                                   // current node (addr to try)
+    posList = next ? next + 16 : 0;                    // advance cursor
+    CClientSocket::Connect(this, saved);
+    return 0;
+}
+```
+`posList - 16 + 4` reads the `m_pNext` field of the `ZRefCountedDummy<ZInetAddr>` node
+(our `ZList::CastNode` subtracts 16; `+4` is the `m_pNext` slot), then `+16` converts the
+node pointer back to the wrapped `ZInetAddr*`. This is exactly `ZList<ZInetAddr>::GetNext`.
+
+### Our implementation
+```cpp
+if (!bSuccess) {
+    if (!pThis->m_ctxConnect.posList) {
+        pThis->Close();
+        if (pThis->m_ctxConnect.bLogin) {
+            Log("CClientSocket::OnConnect connect failed (login) -> RaiseTerminate(0x22000001)");
+            RaiseTerminate(0x22000001);   // [[noreturn]]
+        }
+        Log("CClientSocket::OnConnect connect failed -> RaiseDisconnect(0x21000001)");
+        RaiseDisconnect(0x21000001);      // [[noreturn]]
+    }
+
+    // Advance the load-balancing cursor and retry the *current* node's address.
+    auto* pos = reinterpret_cast<ZInetAddr*>(pThis->m_ctxConnect.posList);
+    ZInetAddr* current = pThis->m_ctxConnect.lAddr.GetNext(&pos);
+    pThis->m_ctxConnect.posList = reinterpret_cast<__POSITION*>(pos);
+    CClientSocket__Connect_Addr_Hook(pThis, edx, reinterpret_cast<const sockaddr_in*>(current));
+    return 0;
+}
+```
+
+Notes
+- `RaiseTerminate` / `RaiseDisconnect` already exist (`bypass/client_exception.{h,cpp}`)
+  and unwind into the stock WinMain handler. They are `[[noreturn]]`; do not add a trailing
+  `return`.
+- `m_ctxConnect.posList` is declared `__POSITION*`; `lAddr` is `ZList<ZInetAddr>`. Casting
+  `posList` ↔ `ZInetAddr*` mirrors how `CClientSocket__Connect_Ctx_Hook` already stores
+  `reinterpret_cast<__POSITION*>(lAddr.GetHeadPosition())`.
+- Passing `ZInetAddr*` as `const sockaddr_in*` matches the existing `Connect_Ctx` path,
+  which calls `Connect_Addr(&pThis->m_addr)` where `m_addr` is a `ZInetAddr`.
+- **Delete** the current line 124 `Connect_Addr_Hook(..., lAddr.GetHeadPosition())` and the
+  `// TODO do i really care to do the loadbalancing logic?` comment.
+
+### Magic-number cross-check
+| Constant | Hex | Exception |
+|---|---|---|
+| 570425345 | `0x22000001` | `CTerminateException` |
+| 553648129 | `0x21000001` | `CDisconnectException` |
+| 570425351 | `0x22000007` | `CTerminateException` (version mismatch — already handled) |
+
+---
+
+## 2. `CLIENT_START_ERROR` relay — `bSuccess && bLogin` branch
+
+### Stock behavior (decompiled, condensed)
+```c
+if (this->m_ctxConnect.bLogin) {
+    char* name = CWvsApp::GetExceptionFileName();
+    CFileStream fs;                 // stack object, vtable = off_B437BC
+    fs.vftable = &off_B437BC;
+    fs.Open(name, /*access*/0x80000000 GENERIC_READ, /*share*/128, 1, /*disp*/0, 0, 0);
+    unsigned len = fs.GetLength();  // sub_49A79E
+    if (len && len < 0x2000) {
+        void* buf = ZArray_SetSize(&report, len);   // sub_49BBBE
+        fs.Read(buf, len);                          // sub_49A8C9
+    }
+    fs.Close();                     // sub_49A5B7  (dtor / handle close)
+    if (report && report.len) {
+        COutPacket pkt(0x19);       // CLIENT_START_ERROR
+        pkt.Encode2(report.len);
+        pkt.EncodeBuffer(report.data, report.len);
+        CClientSocket::SendPacket(this, &pkt);
+        report.RemoveAll();
+    }
+}
+```
+`sub_49A615` confirmed `__thiscall CFileStream::Open(this=ecx; name, access, share, arg3,
+disp, arg5, arg6)`: closes any prior handle (`sub_49A5B7`), calls `CreateFileA`
+(`dword_C49A54`), stores the handle at `[this+0x10]`, throws `ZException` on
+`INVALID_HANDLE_VALUE`. Object fields touched: `[+8]`, `[+0xC]` zeroed; `[+0x34] |= 1`,
+and `|= 2` when the high access bit (`0x40` of byte 3 of access) is set.
+
+### Our implementation (reuse the client stream)
+Stack-construct the file-stream object, install its vtable, and drive it by mapped address.
+
+```cpp
+if (pThis->m_ctxConnect.bLogin) {
+    Log("CClientSocket::OnConnect relaying CLIENT_START_ERROR [%d]", CLIENT_START_ERROR);
+    char* fileName = CWvsApp::GetExceptionFileName();
+
+    ClientFileStream fs{};                       // see struct sketch below
+    fs.vftable = reinterpret_cast<void*>(C_FILE_STREAM_VFTABLE);
+
+    using OpenFn = int(__thiscall*)(void* self, const char* name, unsigned access,
+                                    unsigned share, int a3, unsigned disp, int a5, int a6);
+    using LenFn  = unsigned(__thiscall*)(void* self);
+    using ReadFn = int(__thiscall*)(void* self, void* dst, unsigned len);
+    using CloseFn= void(__thiscall*)(void* self);
+
+    reinterpret_cast<OpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, 0x80000000u, 128, 1, 0, 0, 0);
+    unsigned len = reinterpret_cast<LenFn>(C_FILE_STREAM_GET_LENGTH)(&fs);
+
+    ZArray<char> report;                         // or call C_ZARRAY_BYTE_SETSIZE by addr (OQ-2)
+    if (len && len < 0x2000) {
+        char* dst = report.SetSize(len);         // resolve against common/ZArray.h
+        reinterpret_cast<ReadFn>(C_FILE_STREAM_READ)(&fs, dst, len);
+    }
+    reinterpret_cast<CloseFn>(C_FILE_STREAM_CLOSE)(&fs);
+
+    if (report.GetCount()) {
+        COutPacket pkt(CLIENT_START_ERROR);
+        pkt.Encode2(static_cast<unsigned short>(report.GetCount()));
+        pkt.EncodeBuffer(report.GetData(), report.GetCount());
+        CClientSocket::GetInstance()->SendPacket(&pkt);
+    }
+} else {
+    /* existing PLAYER_LOGGED_IN branch — unchanged */
+}
+```
+
+`ClientFileStream` is a thin stack mirror sized to the stock object; only `vftable@[0]`
+and `handle@[+0x10]` are semantically meaningful to us, but the buffer must be at least the
+full object size so the client methods do not write out of bounds:
+
+```cpp
+struct ClientFileStream {
+    void* vftable;     // [+0x00]  -> C_FILE_STREAM_VFTABLE
+    char  pad[0x30];   // [+0x04]  conservative; confirm exact size (OQ-1)
+};
+```
+
+Open items folded into PRD §9:
+- Confirm exact object size (OQ-1) — size `pad` from the stock stack frame (`v34[12]` =
+  0x30 region in v84.1) and any adjacent fields the methods touch.
+- Decide `ZArray<char>` reuse vs `C_ZARRAY_BYTE_SETSIZE` by address (OQ-2). Prefer the
+  template in `common/ZArray.h` if `SetSize`/`GetData`/`GetCount` already model `sub_49BBBE`.
+
+### Wire format (atlas-login parity)
+`serverbound.StartError.Decode`: `length = ReadUint16(); bytes = ReadBytes(length)`.
+`Encode2` is little-endian u16, `EncodeBuffer` appends raw bytes — exact match. Handled by
+`StartErrorHandleFunc` in
+`atlas/services/atlas-login/atlas.com/login/socket/handler/start_error.go`.
+
+---
+
+## 3. Things that must NOT change
+- Top guard `if (!pThis->m_ctxConnect.lAddr.GetCount()) return 0;`.
+- The handshake decode (`decode_handshake`) and the version/patch ladder
+  (`RaiseTerminate(0x22000007)` / `RaisePatch()`).
+- The non-login `PLAYER_LOGGED_IN` send branch.
+- The `BUILD_MAJOR_VERSION >= 95` `SendPacket` rewrite and its `#if` gate.

--- a/docs/tasks/task-007-socket-connect-fidelity/memory-map.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/memory-map.md
@@ -79,13 +79,27 @@ For each version, `C_FILE_STREAM_RESOLVED = 1` means the four helpers + vtable w
 and will be emitted to that version's cmake; `= 0` means the relay is gated off (helpers are
 `0x0` placeholders in Task 4).
 
-| Version | `C_FILE_STREAM_RESOLVED` | Reason if 0 |
-|---|---|---|
-| GMS v84.1 | `1` | — (anchor verified) |
-| GMS v83.1 | `0` | OnConnect CFG-obfuscated; helpers unrecoverable (see N/A) |
-| GMS v87.1 | `1` | — (symbols present, vtable `off_B95EA4`) |
-| GMS v111.1 | `0` | different stream class — no vtable `__thiscall Open` (see N/A) |
-| JMS v185.1 | `1` | — (vtable `off_BE4CAC`; ⚠️ but report opcode is 0x0F not 0x15) |
+| Version | `C_FILE_STREAM_RESOLVED` | `C_FILE_STREAM_OPEN_INLINE` | Reason if 0 |
+|---|---|---|---|
+| GMS v84.1 | `1` | `0` | — (anchor verified) |
+| GMS v83.1 | `0` | `0` | OnConnect CFG-obfuscated; helpers unrecoverable (see N/A) |
+| GMS v87.1 | `1` | `0` | — (symbols present, vtable `off_B95EA4`) |
+| GMS v95.1 | `1` | `1` | — (inline open; resolved below — CI builds this version) |
+| GMS v111.1 | `0` | `0` | different stream class — no vtable `__thiscall Open` (see N/A) |
+| JMS v185.1 | `1` | `0` | — (vtable `off_BE4CAC`; report opcode corrected 0x15→0x0F) |
+
+> **GMS v95.1 — resolved with inline open (added after CI surfaced that CI builds v95).**
+> v95 has the same `[+0x10]` handle / `[+0x34]` state-flag stream object as v84, but
+> `CClientSocket::OnConnect` (`0x004AEF10`) **inlines `CreateFileA`** instead of exposing a
+> standalone `__thiscall Open(name,access,…)`. The named `ZFileStream` helpers exist:
+> GetLength `0x004ACD30`, Read `0x004ACD60`, Close `0x004AD7C0`, vtable `0x00B49E30`
+> (`??_7ZFileStream@@6B@`). Report opcode confirmed `0x1A` (matches cmake). Object size `0x38`
+> (highest write `[+0x34]`), so the `0x40` `ClientFileStream` covers it.
+> Because there is no `Open()` to call, v95 sets `C_FILE_STREAM_OPEN_INLINE 1` and
+> `C_FILE_STREAM_OPEN 0x0` (unused); the relay replicates the inline open
+> (`CreateFileA(name, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0)`
+> → handle at `[+0x10]`, `[+0x34] |= 1`) then drives the resolved GetLength/Read/Close.
+> `C_FILE_STREAM_OPEN_INLINE` is a new per-version key (0 for every other version).
 
 ## OQ-1 — `ClientFileStream` object size
 Settled on v84.1 (active IDB `GMS_v84.1_U_DEVM.exe`). Stream object = stack var `v34`

--- a/docs/tasks/task-007-socket-connect-fidelity/memory-map.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/memory-map.md
@@ -1,0 +1,164 @@
+# Memory Map — Socket Connect Fidelity
+
+New per-version entries needed for the `CLIENT_START_ERROR` report read. The load-balancing
+fix needs **no** new map entries (it uses our `ZList` + the existing exception `_ThrowInfo`
+map values). Add each symbol to `memory_maps/<REGION>/v<MAJOR>_<MINOR>.cmake` and surface it
+in `include/memory_map.h.in`.
+
+## Already present (verify, do not re-add)
+| Symbol | Where | Notes |
+|---|---|---|
+| `CLIENT_START_ERROR` | `memory_maps/GMS/v84_1.cmake:10` etc. | `0x19` GMS v83–v87, `0x2F` v111, JMS v185 = confirm |
+| `C_WVS_APP_GET_EXCEPTION_FILE_NAME` | `memory_maps/GMS/v84_1.cmake:166` | report path |
+| `C_TI_TERMINATE_EXCEPTION` | exception map | used by `RaiseTerminate(0x22000001)` |
+| `C_TI_DISCONNECT_EXCEPTION` | exception map | used by `RaiseDisconnect(0x21000001)` |
+| `C_CLIENT_SOCKET_ON_CONNECT` | `:29` | hook target |
+
+## New entries (file-stream helper set)
+Resolve per region+version. `off_B437BC` is the stream object's vtable; the four method
+addresses are reachable through it (slots in order: `[0]=Open-preamble/Close`, `[+4]=Read`,
+…), but call them by their flat addresses for clarity.
+
+| Symbol | Meaning | GMS v84.1 | v83.1 | v87.1 | v111.1 | JMS v185.1 |
+|---|---|---|---|---|---|---|
+| `C_FILE_STREAM_OPEN` | `__thiscall Open(name,access,share,…)` → `CreateFileA` | `0x0049A615` | N/A | `0x004A7710` | N/A | `0x004B0864` |
+| `C_FILE_STREAM_GET_LENGTH` | `__thiscall GetLength()` → size | `0x0049A79E` | N/A | `0x004A7899` | N/A | `0x004B09ED` |
+| `C_FILE_STREAM_READ` | `__thiscall Read(dst,len)` | `0x0049A8C9` | N/A | `0x004A79C4` | N/A | `0x004B0B18` |
+| `C_FILE_STREAM_CLOSE` | `__thiscall Close()` / dtor | `0x0049A5B7` | N/A | `0x004A76B2` | N/A | `0x004B0806` |
+| `C_FILE_STREAM_VFTABLE` | stream object vtable | `0x00B437BC` | N/A | `0x00B95EA4` | N/A | `0x00BE4CAC` |
+| `C_ZARRAY_BYTE_SETSIZE` | report buffer resize (`sub_49BBBE`) | resolved-via-template (OQ-2) | — | — | — | — |
+
+### Per-version audit anchors (reproducibility)
+Each row resolved by decompiling that version's `CClientSocket::OnConnect`
+(`C_CLIENT_SOCKET_ON_CONNECT`), locating the `bLogin` branch (the
+`if (m_ctxConnect.bLogin)` arm that calls `CWvsApp::GetExceptionFileName`), and reading the
+four helpers in call order. `select_instance` + `server_health` confirmed each IDB before
+recording.
+
+| Version | Port | `server_health` module | `OnConnect` (cmake `C_CLIENT_SOCKET_ON_CONNECT`) | report opcode pushed to `COutPacket` ctor | cmake `CLIENT_START_ERROR` |
+|---|---|---|---|---|---|
+| GMS v84.1 | 13341 | `GMS_v84.1_U_DEVM.exe` | `0x00499DCD` | `0x19` (push 19h @ 0x49A2A0) | `0x19` ✅ |
+| GMS v83.1 | 13337 | `MapleStory_dump.exe` | `0x00494ED1` | (unrecoverable — CFG-obfuscated) | `0x19` |
+| GMS v87.1 | 13338 | `GMSv87_4GB.exe` | `0x004A6E5A` | `0x19` (push 19h @ 0x4A735A) | `0x19` ✅ |
+| GMS v111.1 | 13342 | `MapleStory v111.5_dump_SCY.exe` | `0x004DA820` | `0x2F` (push 2Fh @ 0x4DACF2) | `0x2F` ✅ |
+| JMS v185.1 | 13340 | `MapleStory_dump_SCY.exe` | `0x004B0066` | **`0x0F`** (push 0Fh @ 0x4B04B4) | **`0x15`** ⚠️ MISMATCH |
+
+> ⚠️ **JMS v185.1 opcode discrepancy (flagged loudly).** The cmake declares
+> `CLIENT_START_ERROR 0x15` (`memory_maps/JMS/v185_1.cmake:4`), but the bLogin error-report
+> `COutPacket` ctor in `OnConnect` is unambiguously `push 0Fh` (verified at raw
+> `0x004B04B4`). The non-login start packet in the same function is `push 7` (0x07). So in
+> JMS185 the start-error report opcode is **0x0F**, not 0x15. This does not block the
+> file-stream resolution (helpers are fully resolved), but Task 4/Task 5 must NOT trust the
+> existing `0x15` for the JMS report relay — either re-derive the opcode or carry a separate
+> `CLIENT_START_ERROR` value for JMS185. Recommend a follow-up to reconcile `v185_1.cmake:4`.
+
+### N/A rows — reasons (no guessing; `0x0` placeholders + RESOLVED 0 in Task 4)
+- **v83.1 — N/A (OnConnect CFG-obfuscated).** `OnConnect @ 0x00494ED1` is a faithful body
+  (same `0xFAC` frame, same `var_A0` stream object, same `var_40/var_70` scratch as v84) but
+  it is wrapped by a control-flow obfuscator: the first instructions `jmp loc_D102F3` into a
+  relocated/flattened body in the `0x00C22xxx`/`0x00D102xx` region, full of
+  `_InterlockedExchange` opaque predicates and `JUMPOUT`s. The linear Open→GetLength→Read→
+  Close call sequence is not statically recoverable, and `CWvsApp::GetExceptionFileName`
+  (`0x009F9808`) has **no xref into OnConnect** (only `WriteClientLog`, `save_error_log`,
+  `_WinMain`). Cannot resolve the helpers without guessing → N/A.
+- **v111.1 — N/A (different stream class; no vtable `__thiscall Open`).** The bLogin branch
+  (`if (v16[9])`) does NOT use the v84-style vtable stream object. "Open" is the **raw
+  `CreateFileA` import thunk** `dword_100F86C(name, 0x80000000, 1, 0, 3, 128, 0)` (handle
+  stored at `v55`, throws `ZException` if `== -1`), not a `__thiscall Open(name,access,…)`
+  method, and no `off_xxx` vtable is assigned to the stream object. The surrounding helpers
+  are a redesigned ZFileStream (`sub_4D86B0` ctor, `sub_4D8D80` open/close,
+  `sub_4D8300` GetLength, `sub_4D8330` Read). The `C_FILE_STREAM_*` symbol set is defined
+  for the vtable-object model, which v111 does not have → N/A for this symbol set.
+  (For the audit only, the v111 analogs are: ctor `0x004D86B0`, open/close `0x004D8D80`,
+  GetLength `0x004D8300`, Read `0x004D8330`, CreateFile thunk `0x0100F86C`. These are NOT
+  recorded as `C_FILE_STREAM_*` because the shape differs; Task 5's `ClientFileStream` cannot
+  faithfully reconstruct them.) COutPacket report opcode `0x2F` confirmed.
+
+## RESOLVED flags (drives Task 4 cmake plumbing)
+For each version, `C_FILE_STREAM_RESOLVED = 1` means the four helpers + vtable were verified
+and will be emitted to that version's cmake; `= 0` means the relay is gated off (helpers are
+`0x0` placeholders in Task 4).
+
+| Version | `C_FILE_STREAM_RESOLVED` | Reason if 0 |
+|---|---|---|
+| GMS v84.1 | `1` | — (anchor verified) |
+| GMS v83.1 | `0` | OnConnect CFG-obfuscated; helpers unrecoverable (see N/A) |
+| GMS v87.1 | `1` | — (symbols present, vtable `off_B95EA4`) |
+| GMS v111.1 | `0` | different stream class — no vtable `__thiscall Open` (see N/A) |
+| JMS v185.1 | `1` | — (vtable `off_BE4CAC`; ⚠️ but report opcode is 0x0F not 0x15) |
+
+## OQ-1 — `ClientFileStream` object size
+Settled on v84.1 (active IDB `GMS_v84.1_U_DEVM.exe`). Stream object = stack var `v34`
+(`_DWORD[12]` @ `ebp-A0h`), vtable `off_B437BC` stored at `[+0]`. Highest byte offset
+**written** by any of the four methods:
+
+| Method | addr | writes (this-relative offsets) |
+|---|---|---|
+| Open `sub_49A615` | `0x49A615` | `[+8]=0`, `[+0xC]=0`, `[+0x10]=handle`, `[+0x34]` dword (`or [esi+34h],1`; optional `or …,2`) |
+| GetLength `sub_49A79E` | `0x49A79E` | none (calls vtable `[*this+0x3C]`, reads position only) |
+| Read `sub_49A8C9` | `0x49A8C9` | `[+8]/[+0xC]` 64-bit file position (reads `[+0x18],[+0x20],[+0x28]`; Seek helper `sub_49A74B` writes nothing in the object) |
+| Close `sub_49A5B7` | `0x49A5B7` | `[+0x10]=-1`, `[+0x34]` dword (`and [esi+34h],0`) |
+
+- **Highest offset written:** the **dword at `[+0x34]`** → bytes `0x34..0x37`, i.e. **highest
+  written byte = `0x37`**.
+- **Minimum object size:** **`0x38`** (`0x34` dword + 4).
+- **Recommended for Task 5's `ClientFileStream`:** total **`0x40`**, layout
+  `{ void* vtbl @ +0; ... ; pad to 0x40 }` → **`pad[0x3C]`** after the vtable pointer
+  (`0x40 − 4`). This is the conservative recommendation; the strict minimum is `0x38`
+  (`pad[0x34]`). No method writes above `[+0x37]`, so `0x40` is safe with headroom.
+
+## OQ-throw — missing-file behavior → decision **(b)**
+Settled on v84.1 from the Open disassembly (`sub_49A615 @ 0x0049A615`):
+
+```
+0x49A650  call dword_C49A54          ; CreateFileA wrapper (GENERIC_READ)
+0x49A656  cmp  eax, 0FFFFFFFFh        ; INVALID_HANDLE_VALUE ?
+0x49A659  mov  [esi+10h], eax         ; store handle
+0x49A65C  jnz  short loc_49A675       ; ok
+0x49A65E  call dword_C49AA4           ; GetLastError
+0x49A664  mov  [ebp+pExceptionObject], eax
+0x49A670  call __CxxThrowException@8  ; throw ZException  ← on missing file
+```
+
+`C_FILE_STREAM_OPEN` **DOES throw `ZException` when `CreateFileA` returns
+`INVALID_HANDLE_VALUE`** — i.e. on a routine missing report file. (It also throws earlier if
+the pre-emptive `Close`/`sub_49A5B7` preamble fails, but the missing-file case is the
+CreateFile `== -1` path above.) In `OnConnect`'s bLogin branch the `Open`→`GetLength`→`Read`→
+`Close` sequence is **NOT wrapped in its own try/catch** that swallows this — the only
+enclosing handler is the function-level EH unwind frame (`v53`/`v62` state machine), so a
+throw here **escapes** `OnConnect` and unwinds up the stack. This contradicts the requirement
+"a routine missing/empty report must produce NO packet and NO exception/crash."
+
+- **Decision: (b).** Task 5 MUST pre-check existence before opening so a normal missing report
+  never throws.
+- **Required guard (exact):** before constructing/opening the `ClientFileStream`, skip the
+  entire relay when the report path does not exist —
+  `if (GetFileAttributesA(path) == INVALID_FILE_ATTRIBUTES) return;`
+  (equivalently `PathFileExistsA(path)` / a `CreateFileA(...OPEN_EXISTING...)` probe). Only
+  call `Open` when the file is known to exist. The existing `(0 < len < 0x2000)` guard on
+  `GetLength` handles the empty/oversized cases but does **not** cover the missing-file throw,
+  which happens earlier inside `Open`. The pre-existence check is mandatory.
+
+> OQ-throw applies identically to v87.1 and JMS185.1 (same vtable-Open model — Open throws on
+> `-1`). v111.1's inlined variant also throws on `CreateFileA == -1` (raw thunk path), so the
+> same pre-existence guard is correct there too, even though that version's relay is gated off.
+
+## OQ-2 — `C_ZARRAY_BYTE_SETSIZE` resolved-via-template (NOT a memory-map symbol)
+The v84 report-buffer resize (`sub_49BBBE`, the `ZArray<unsigned char>::_Alloc`/grow used as
+`v22 = sub_49BBBE(len, &namelen[3])` in OnConnect) is now modeled in `common/ZArray.h` via the
+`Alloc`/`SetSize`/`GetData` template (Task 1). It is therefore **NOT added to the cmake files**
+and **NOT surfaced in `memory_map.h.in`** — the C++ template reproduces the behavior. The
+`C_ZARRAY_BYTE_SETSIZE` row above is kept only for traceability and marked
+`resolved-via-template (OQ-2)`; Task 4 should not plumb it.
+
+## Resolution recipe (per IDB)
+1. `select_instance(port)` then `server_health` to confirm the loaded IDB is the intended version.
+2. Decompile the version's `CClientSocket::OnConnect`; find the `bLogin` branch.
+3. The call right after `GetExceptionFileName()` with `0x80000000` (GENERIC_READ) is
+   `C_FILE_STREAM_OPEN`; the vtable assigned to the stack object just before it is
+   `C_FILE_STREAM_VFTABLE`. The subsequent length / resize / read / close calls map to the
+   remaining symbols in order.
+4. Confirm the `COutPacket` ctor argument equals the version's `CLIENT_START_ERROR` opcode.
+5. If helpers are inlined / the stream object is impractical to reconstruct, mark the version
+   `N/A` with a one-line reason (`0x0` placeholders + `C_FILE_STREAM_RESOLVED 0` in Task 4).
+   Never invent an address.

--- a/docs/tasks/task-007-socket-connect-fidelity/memory-map.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/memory-map.md
@@ -151,6 +151,34 @@ and **NOT surfaced in `memory_map.h.in`** — the C++ template reproduces the be
 `C_ZARRAY_BYTE_SETSIZE` row above is kept only for traceability and marked
 `resolved-via-template (OQ-2)`; Task 4 should not plumb it.
 
+## Decisions for Task 4 / Task 5 (post-audit, 2026-06-12)
+
+An independent IDA + atlas-ms audit re-derived every RESOLVED-1 address (v87.1, JMS185.1)
+and re-confirmed OQ-1 / OQ-throw from v84.1. All addresses, the `0x38` min size, and the
+`(b)` throw decision are **CONFIRMED**. The audit further resolved the JMS opcode:
+
+1. **JMS v185.1 `CLIENT_START_ERROR` → change `0x15` to `0x0F`.** The JMS client's bLogin
+   report `COutPacket` ctor is unambiguously `push 0Fh` (raw `0x004B04B4`); `0x15` has no
+   basis on either wire end (atlas-login's JMS v185 tenant template registers *no* StartError
+   handler at `0x0F` or `0x15`). For client fidelity (the goal of task-007) the relay must
+   send what the stock client sends. **Task 4 must set `CLIENT_START_ERROR 0x0F` in
+   `memory_maps/JMS/v185_1.cmake`** (was `0x15`), with a comment citing this evidence.
+   - *Out of scope (flagged for the record):* atlas-login JMS v185 has no `StartErrorHandle`
+     binding, so the server currently ignores this packet. That is a server-side gap to fix
+     in atlas-ms separately; it does not change the client-fidelity requirement here.
+
+2. **Task 5 needs the missing-file guard (OQ-throw (b)).** Before opening the stream, skip
+   the whole relay when the report path does not exist:
+   `if (GetFileAttributesA(fileName) == INVALID_FILE_ATTRIBUTES) { /* no report */ }`
+   — only call `Open` when the file exists. Applies to every RESOLVED-1 version
+   (v84.1/v87.1/JMS185.1); the `(0 < len < 0x2000)` GetLength guard does NOT cover the throw.
+
+3. **Task 5 `ClientFileStream` size:** total `0x40` → `{ void* vftable; char pad[0x3C]; }`
+   (min `0x38`, conservative `0x40`).
+
+4. **N/A versions confirmed defensible:** v83.1 (genuine CFG flattening), v111.1 (redesigned
+   non-vtable stream class). Both → `C_FILE_STREAM_RESOLVED 0` + `0x0` placeholders in Task 4.
+
 ## Resolution recipe (per IDB)
 1. `select_instance(port)` then `server_health` to confirm the loaded IDB is the intended version.
 2. Decompile the version's `CClientSocket::OnConnect`; find the `bLogin` branch.

--- a/docs/tasks/task-007-socket-connect-fidelity/plan.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/plan.md
@@ -1,0 +1,491 @@
+# Socket Connect Fidelity — Load Balancing & CLIENT_START_ERROR Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the stock client's connect load-balancing (node-by-node address retry + typed-exception exhaustion) and the `CLIENT_START_ERROR` exception-report relay inside the existing `CClientSocket__OnConnect_Hook`, gated to compile and link across GMS v83.1/v84.1/v87.1/v111.1 and JMS v185.1.
+
+**Architecture:** Two in-place rewrites inside one hook (`bypass/socket_hooks.cpp`). The `!bSuccess` block advances the `m_ctxConnect.posList` cursor via the existing `ZList<ZInetAddr>::GetNext` idiom and, on exhaustion, `Close()`s + raises `RaiseTerminate`/`RaiseDisconnect` (both `[[noreturn]]`). The `bSuccess && bLogin` block reconstructs the stock `CFileStream` stack object, drives `Open/GetLength/Read/Close` by mapped address into a `ZArray<char>`, and emits `COutPacket(CLIENT_START_ERROR)`. Five new per-version memory-map symbols plus a compile-time resolution guard plumb the file-stream helpers.
+
+**Tech Stack:** C++ (MSVC/clang-cl, Win32 DLL), CMake `configure_file`-generated `memory_map.h`, IDA Pro MCP for per-version address resolution, `scripts/wsl-build.sh` (clang-cl + xwin) for compile/link verification.
+
+---
+
+## Verification model (read first)
+
+This repo has **no unit-test framework**. "Verification" for a code task means a clean cross-compile + link via `scripts/wsl-build.sh`, plus — for the addresses — IDA disassembly evidence, plus runtime smoke checks against the loaded IDB. Build invocation:
+
+```bash
+scripts/wsl-build.sh <REGION> <MAJOR> <MINOR>
+# e.g.  scripts/wsl-build.sh GMS 84 1   |   scripts/wsl-build.sh JMS 185 1
+```
+
+A clean build ends with all edit DLLs + the proxy linked and exit code 0. The acceptance build matrix is: `GMS 83 1`, `GMS 84 1`, `GMS 87 1`, `GMS 111 1`, `JMS 185 1`.
+
+**Commit after every task.** Never commit to `main` — work on a feature branch (see Task 0).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `common/ZArray.h` | `ZArray<T>` template | Add `SetSize(size_t)` + `GetData()` (report buffer) |
+| `bypass/socket_hooks.cpp` | `CClientSocket__OnConnect_Hook` | Rewrite `!bSuccess` load-balancing block; rewrite `bLogin` relay block; add `ClientFileStream` mirror + fn-ptr typedefs |
+| `include/memory_map.h.in` | generated-header template | Surface 5 `C_FILE_STREAM_*` defines + `C_FILE_STREAM_RESOLVED` guard |
+| `memory_maps/GMS/v83_1.cmake` | per-version symbols | Add the 6 new `set()` entries |
+| `memory_maps/GMS/v84_1.cmake` | per-version symbols | Add the 6 new `set()` entries (values known) |
+| `memory_maps/GMS/v87_1.cmake` | per-version symbols | Add the 6 new `set()` entries |
+| `memory_maps/GMS/v111_1.cmake` | per-version symbols | Add the 6 new `set()` entries |
+| `memory_maps/JMS/v185_1.cmake` | per-version symbols | Add the 6 new `set()` entries |
+| `docs/tasks/task-007-socket-connect-fidelity/memory-map.md` | resolved-address record | Fill in the TBD table from IDA evidence |
+
+**Hard constraint (CMake):** `cmake/GenerateMemoryMap.cmake` scans `memory_map.h.in` for every `@KEY@` and `FATAL_ERROR`s if the selected version's `.cmake` leaves it **undefined or empty**. Therefore every new `@KEY@` must be `set()` to a **non-empty** value in **all five** `.cmake` files — real address where resolved, or a placeholder (`0x0`) **paired with the `C_FILE_STREAM_RESOLVED 0` guard** so the placeholder is never called at runtime.
+
+---
+
+## Task 0: Branch setup
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create a feature branch off main**
+
+Run:
+```bash
+git checkout -b feat/task-007-socket-connect-fidelity
+git status
+```
+Expected: on branch `feat/task-007-socket-connect-fidelity`; only the untracked `docs/tasks/task-007-socket-connect-fidelity/` present.
+
+---
+
+## Task 1: `ZArray<char>` report buffer — `SetSize` / `GetData`
+
+Model the stock `sub_49BBBE` report-buffer resize in the template (design §4, resolves PRD OQ-2) so the relay reads into a `ZArray<char>` instead of calling a by-address helper. These are additive, header-only, non-virtual methods; no existing caller changes.
+
+**Files:**
+- Modify: `common/ZArray.h` (add two methods inside `public:`, near `Alloc` / `GetTailPosition`)
+
+- [ ] **Step 1: Add `SetSize` and `GetData`**
+
+Insert these two methods into the `public:` section of `ZArray<T>` (e.g. immediately after `GetTailPosition()` at `common/ZArray.h:275`):
+
+```cpp
+	/// <summary>
+	/// Allocate exactly n elements, set the count header to n, and return the
+	/// data pointer. Models the stock report-buffer resize (sub_49BBBE) for a
+	/// fresh read into an empty array: Alloc() frees any prior block, allocates
+	/// n*sizeof(T)+sizeof(PVOID), and writes the count header = n.
+	/// </summary>
+	T* SetSize(size_t n)
+	{
+		this->Alloc(n);
+		return this->a;
+	}
+
+	/// <summary>
+	/// Raw pointer to element 0 (base of the allocation, after the count header).
+	/// Intention-revealing alias of GetTailPosition() for buffer call sites.
+	/// </summary>
+	T* GetData()
+	{
+		return this->a;
+	}
+```
+
+Note: `Alloc(size_t)` already exists at `common/ZArray.h:301` and does exactly "RemoveAll, allocate `n*sizeof(T)+sizeof(PVOID)`, write count header `= n`, point `a` past the header." `GetCount()` then returns `n`. No change to `Alloc`.
+
+- [ ] **Step 2: Build-verify (header-only change compiles)**
+
+Run:
+```bash
+scripts/wsl-build.sh GMS 84 1
+```
+Expected: exit code 0, all DLLs linked. (`ZArray.h` is included widely; a clean build proves the additive methods don't break any TU.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add common/ZArray.h
+git commit -m "feat(ZArray): add SetSize/GetData for the report buffer"
+```
+
+---
+
+## Task 2: Load-balancing rewrite (`!bSuccess` block)
+
+Replace the dead `!bSuccess` body (`bypass/socket_hooks.cpp:113-126`) — the two `Log(...) return 0` exhaustion stubs and the `GetHeadPosition()` re-pass marked `// TODO do i really care...` — with faithful cursor advancement + typed-exception exhaustion (design §2, hook-design.md §1). This needs **no** new memory-map symbols and applies **unconditionally** to every version.
+
+**Files:**
+- Modify: `bypass/socket_hooks.cpp:113-126`
+
+- [ ] **Step 1: Replace the `!bSuccess` block**
+
+Replace exactly these lines:
+
+```cpp
+    if (!bSuccess) {
+        if (!pThis->m_ctxConnect.posList) {
+            pThis->Close();
+            if (pThis->m_ctxConnect.bLogin) {
+                Log("CClientSocket::OnConnect 570425345");
+                return 0;
+            }
+            Log("CClientSocket::OnConnect 553648129");
+            return 0;
+        }
+        // TODO do i really care to do the loadbalancing logic?
+        CClientSocket__Connect_Addr_Hook(pThis, edx, pThis->m_ctxConnect.lAddr.GetHeadPosition());
+        return 0;
+    }
+```
+
+with:
+
+```cpp
+    if (!bSuccess) {
+        if (!pThis->m_ctxConnect.posList) {
+            // Address list exhausted: close and raise the stock typed exception,
+            // which unwinds into the client WinMain handler (both [[noreturn]]).
+            pThis->Close();
+            if (pThis->m_ctxConnect.bLogin) {
+                Log("CClientSocket::OnConnect connect failed (login) -> RaiseTerminate(0x22000001)");
+                RaiseTerminate(0x22000001);   // CTerminateException, magic 570425345
+            }
+            Log("CClientSocket::OnConnect connect failed -> RaiseDisconnect(0x21000001)");
+            RaiseDisconnect(0x21000001);       // CDisconnectException, magic 553648129
+        }
+
+        // Advance the load-balancing cursor (GetNext returns the current node and
+        // moves posList to node->m_pNext) and retry the *current* node's address.
+        auto* pos = reinterpret_cast<ZInetAddr*>(pThis->m_ctxConnect.posList);
+        ZInetAddr* current = pThis->m_ctxConnect.lAddr.GetNext(&pos);
+        pThis->m_ctxConnect.posList = reinterpret_cast<__POSITION*>(pos);
+        CClientSocket__Connect_Addr_Hook(pThis, edx, current);   // ZInetAddr : sockaddr_in
+        return 0;
+    }
+```
+
+Why this is correct (do not re-derive the pointer math):
+- `ZList<ZInetAddr>::GetNext(T** pos)` (`common/ZList.h:333`) returns `*pos` and advances `*pos` to the wrapped `m_pNext` via `CastNode` (subtract 16) — exactly the stock `posList-16+4 -> m_pNext`, `+16 -> ZInetAddr*` idiom in hook-design.md §1.
+- `ZInetAddr` is `struct ZInetAddr : sockaddr_in` (`common/ZInetAddr.h:3`), so passing `current` where `CClientSocket__Connect_Addr_Hook` expects `const sockaddr_in*` is a plain base-class conversion — no cast on the argument (mirrors `Connect_Ctx_Hook` passing `&pThis->m_addr`).
+- The `posList ↔ __POSITION*` casts mirror the existing `reinterpret_cast<__POSITION*>(...GetHeadPosition())` in `Connect_Ctx_Hook` (`socket_hooks.cpp:282`).
+- `RaiseTerminate`/`RaiseDisconnect` are declared `[[noreturn]]` (`bypass/client_exception.h:8-9`); **no trailing `return`** after them — the exhaustion branch cannot fall through into the success path.
+
+- [ ] **Step 2: Build-verify**
+
+Run:
+```bash
+scripts/wsl-build.sh GMS 84 1
+```
+Expected: exit code 0, clean link, no new warnings in `socket_hooks.cpp`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bypass/socket_hooks.cpp
+git commit -m "feat(socket): restore connect load-balancing + typed-exception exhaustion"
+```
+
+---
+
+## Task 3: Resolve file-stream helper addresses + v84.1 disassembly facts (IDA)
+
+Resolve the per-version `C_FILE_STREAM_*` addresses and settle the two open disassembly questions (OQ-1 object size, OQ-throw missing-file behavior). This task produces **evidence + an address table**, written into `docs/tasks/task-007-socket-connect-fidelity/memory-map.md`. No source builds here.
+
+**Files:**
+- Modify: `docs/tasks/task-007-socket-connect-fidelity/memory-map.md` (fill TBD table + record OQ-1 size and OQ-throw decision)
+
+**Known v84.1 anchors** (loaded IDB `GMS_v84.1_U_DEVM`, `CClientSocket::OnConnect @ 0x00499DCD`):
+
+| Symbol | v84.1 |
+|---|---|
+| `C_FILE_STREAM_OPEN` | `0x0049A615` |
+| `C_FILE_STREAM_GET_LENGTH` | `0x0049A79E` |
+| `C_FILE_STREAM_READ` | `0x0049A8C9` |
+| `C_FILE_STREAM_CLOSE` | `0x0049A5B7` |
+| `C_FILE_STREAM_VFTABLE` | `0x00B437BC` |
+
+- [ ] **Step 1: Confirm the loaded IDB before any probe**
+
+Use `mcp__ida-pro__get_metadata` (or `entity_query`/server_health) to confirm which IDB is loaded. **Do not infer the version from conversation context** (per the verify-IDA-target rule). Record the version string.
+
+- [ ] **Step 2: Resolve OQ-1 (object size) from v84.1**
+
+With the v84.1 IDB loaded, decompile `CClientSocket::OnConnect` (`0x00499DCD`) and the `bLogin` branch. Find the stack object whose vtable is `0x00B437BC` and that `0x0049A615` (`Open`) is called on. Determine the **highest byte offset** any of `Open/GetLength/Read/Close` writes within that object. Known so far: `Open` zeroes `[+8]`,`[+0xC]` and ORs flags into `[+0x34]` (a dword → writes through `[+0x37]`), stores the handle at `[+0x10]`. Record the exact size.
+
+**Note — the design's `pad[0x30]` is too small:** vftable (4 bytes) + `pad[0x30]` = `0x34` total, but a dword write at `[+0x34]` needs the object to be ≥ `0x38` bytes. Size `pad` so the **total object ≥ (highest offset written + 4), rounded up** — e.g. `pad[0x3C]` (total `0x40`) is a safe conservative cover for a `[+0x34]` dword write, matching the RaisePatch "2048 ≥ 1288" conservative-buffer precedent. Record the chosen total size for Task 5.
+
+- [ ] **Step 3: Resolve OQ-throw (missing-file behavior) from v84.1**
+
+Inspect `C_FILE_STREAM_OPEN` (`sub_49A615`) and the `OnConnect` `bLogin` branch: does `Open` throw `ZException` on `INVALID_HANDLE_VALUE`, and if so is that throw caught locally in `OnConnect` or does it escape? Reconcile with FR-11 ("missing/empty report → no packet, no exception"). Record the finding and the required guard in Task 5:
+  - If `OnConnect` reaches `GetLength` (returns 0) without `Open` throwing on a routine missing file, the `(0 < len < 0x2000)` guard alone is sufficient (no extra guard).
+  - If `Open` **can** throw on a routine missing file, Task 5 must pre-check existence (e.g. skip the whole relay when `GetExceptionFileName()` returns a path that does not exist) so a normal missing report never crashes the client.
+
+- [ ] **Step 4: Resolve the other four versions' addresses**
+
+For each of v83.1, v87.1, v111.1, JMS v185.1: load that IDB (confirm via `get_metadata` first), decompile its `CClientSocket::OnConnect`, find the `bLogin` branch, and map the helpers using the recipe in `memory-map.md` §"Resolution recipe":
+  - The call right after `GetExceptionFileName()` taking `0x80000000` (GENERIC_READ) is `C_FILE_STREAM_OPEN`; the vtable assigned to the stack object just before it is `C_FILE_STREAM_VFTABLE`; the subsequent length/read/close calls map in order.
+  - Confirm the `COutPacket` ctor argument equals that version's `CLIENT_START_ERROR` opcode (already mapped: `0x19` v83/v84/v87, `0x2F` v111, `0x15` JMS185).
+  - If a version's helpers are inlined / the object is impractical to reconstruct, mark that version **`N/A` with a one-line reason** — it will use a `0x0` placeholder + `C_FILE_STREAM_RESOLVED 0` guard in Task 4 (pre-approved by PRD §7 / design §6).
+
+- [ ] **Step 5: Record everything in `memory-map.md`**
+
+Fill the per-version table (replace every `TBD`), record the OQ-1 total object size, the OQ-throw decision, and which versions are `RESOLVED=1` vs `RESOLVED=0`. This file is the source of truth for Tasks 4 and 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/tasks/task-007-socket-connect-fidelity/memory-map.md
+git commit -m "docs(task-007): resolve file-stream helper addresses + OQ-1/OQ-throw"
+```
+
+---
+
+## Task 4: Memory-map plumbing (6 symbols × 5 versions + template)
+
+Surface the file-stream helper set and a compile-time resolution guard. Every `@KEY@` must be non-empty in all five `.cmake` files (CMake hard constraint above).
+
+**Files:**
+- Modify: `include/memory_map.h.in` (add 6 defines)
+- Modify: `memory_maps/GMS/v83_1.cmake`, `v84_1.cmake`, `v87_1.cmake`, `v111_1.cmake`, `memory_maps/JMS/v185_1.cmake` (add 6 `set()` each)
+
+- [ ] **Step 1: Add the six defines to `memory_map.h.in`**
+
+Append after the exception-dispatch block at the end of `include/memory_map.h.in`:
+
+```c
+
+// --- File-stream report read for CLIENT_START_ERROR (docs/tasks/task-007-socket-connect-fidelity) ---
+// C_FILE_STREAM_RESOLVED is 1 when this version's stream helpers were resolved
+// from its IDB, 0 when the relay body is gated off (placeholder addresses).
+#define C_FILE_STREAM_RESOLVED @C_FILE_STREAM_RESOLVED@
+#define C_FILE_STREAM_OPEN @C_FILE_STREAM_OPEN@
+#define C_FILE_STREAM_GET_LENGTH @C_FILE_STREAM_GET_LENGTH@
+#define C_FILE_STREAM_READ @C_FILE_STREAM_READ@
+#define C_FILE_STREAM_CLOSE @C_FILE_STREAM_CLOSE@
+#define C_FILE_STREAM_VFTABLE @C_FILE_STREAM_VFTABLE@
+```
+
+- [ ] **Step 2: Add the six `set()` entries to `memory_maps/GMS/v84_1.cmake`**
+
+Append (values known and confirmed in Task 3):
+
+```cmake
+set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN         0x0049A615) # __thiscall CFileStream::Open(name,access,share,…) -> CreateFileA
+set(C_FILE_STREAM_GET_LENGTH   0x0049A79E) # __thiscall GetLength() -> size
+set(C_FILE_STREAM_READ         0x0049A8C9) # __thiscall Read(dst,len)
+set(C_FILE_STREAM_CLOSE        0x0049A5B7) # __thiscall Close()/dtor
+set(C_FILE_STREAM_VFTABLE      0x00B437BC) # stream object vtable
+```
+
+- [ ] **Step 3: Add the six `set()` entries to the other four `.cmake` files**
+
+Using the addresses resolved in Task 3, append the same six-line block to `memory_maps/GMS/v83_1.cmake`, `memory_maps/GMS/v87_1.cmake`, `memory_maps/GMS/v111_1.cmake`, and `memory_maps/JMS/v185_1.cmake` — substituting that version's real addresses and `C_FILE_STREAM_RESOLVED 1`.
+
+For any version marked **`N/A`** in Task 3, use this gated form instead (non-empty placeholders keep CMake happy; the `RESOLVED 0` guard makes Task 5 emit a Log-only no-op so `0x0` is never called):
+
+```cmake
+set(C_FILE_STREAM_RESOLVED     0)          # relay gated off: <one-line reason from Task 3>
+set(C_FILE_STREAM_OPEN         0x0)
+set(C_FILE_STREAM_GET_LENGTH   0x0)
+set(C_FILE_STREAM_READ         0x0)
+set(C_FILE_STREAM_CLOSE        0x0)
+set(C_FILE_STREAM_VFTABLE      0x0)
+```
+
+- [ ] **Step 4: Configure-verify every version resolves its keys**
+
+Run each build to prove `GenerateMemoryMap.cmake` finds all keys (a missing/empty key is a `FATAL_ERROR` at configure time):
+
+```bash
+scripts/wsl-build.sh GMS 83 1
+scripts/wsl-build.sh GMS 84 1
+scripts/wsl-build.sh GMS 87 1
+scripts/wsl-build.sh GMS 111 1
+scripts/wsl-build.sh JMS 185 1
+```
+Expected: each configures past the memory-map validation and links cleanly (the relay body is added in Task 5; the new symbols are defined but not yet referenced, so this is purely a plumbing check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/memory_map.h.in memory_maps/GMS/v83_1.cmake memory_maps/GMS/v84_1.cmake \
+        memory_maps/GMS/v87_1.cmake memory_maps/GMS/v111_1.cmake memory_maps/JMS/v185_1.cmake
+git commit -m "feat(memory-map): add file-stream helper set + resolution guard"
+```
+
+---
+
+## Task 5: `CLIENT_START_ERROR` relay (`bLogin` block)
+
+Replace the `bLogin` stub (`bypass/socket_hooks.cpp:210-213` — the `// TODO relay CLIENT_START_ERROR` and the dropped `GetExceptionFileName()`) with the faithful report read + send (design §3, hook-design.md §2). The non-login `PLAYER_LOGGED_IN` `else` branch is unchanged.
+
+**Files:**
+- Modify: `bypass/socket_hooks.cpp` (add `ClientFileStream` mirror + typedefs near the top file-scope helpers; rewrite the `bLogin` branch body)
+
+- [ ] **Step 1: Add the `ClientFileStream` mirror + fn-ptr typedefs**
+
+In `bypass/socket_hooks.cpp`, just below the existing `// ---- typedefs ----` block (after line 22, before the anonymous namespace), add:
+
+```cpp
+// ---- CLIENT_START_ERROR report-read mirror (§3) -------------------------
+// Thin stack mirror of the stock CFileStream object. Only vftable@[0] and
+// handle@[+0x10] are semantically meaningful to us, but the buffer MUST be at
+// least the full stock object size so Open/Read/Close do not write OOB.
+// `pad` is sized from the v84.1 stack frame (Task 3 / OQ-1): Open writes a dword
+// at [+0x34], so total object >= 0x38; pad[0x3C] (total 0x40) is the conservative
+// cover. Adjust only if Task 3 found a larger footprint.
+struct ClientFileStream {
+    void* vftable;     // [+0x00] -> C_FILE_STREAM_VFTABLE
+    char  pad[0x3C];   // [+0x04] conservative; covers the [+0x34] flag write
+};
+
+using FileStreamOpenFn  = int(__thiscall*)(void* self, const char* name, unsigned access,
+                                           unsigned share, int a3, unsigned disp, int a5, int a6);
+using FileStreamLenFn   = unsigned(__thiscall*)(void* self);
+using FileStreamReadFn  = int(__thiscall*)(void* self, void* dst, unsigned len);
+using FileStreamCloseFn = void(__thiscall*)(void* self);
+```
+
+> If Task 3 recorded a total object size larger than `0x40`, set `pad` to `(total size − 4)` instead of `0x3C`.
+
+- [ ] **Step 2: Rewrite the `bLogin` branch body**
+
+Replace exactly:
+
+```cpp
+    if (pThis->m_ctxConnect.bLogin) {
+        Log("CClientSocket::OnConnect should be sending [%d]", CLIENT_START_ERROR);
+        // TODO relay CLIENT_START_ERROR
+        char* fileName = CWvsApp::GetExceptionFileName();
+    } else {
+```
+
+with (the `#if C_FILE_STREAM_RESOLVED` guard makes gated-off versions a Log-only no-op so placeholder `0x0` addresses are never called):
+
+```cpp
+    if (pThis->m_ctxConnect.bLogin) {
+        Log("CClientSocket::OnConnect relaying CLIENT_START_ERROR [%d]", CLIENT_START_ERROR);
+#if C_FILE_STREAM_RESOLVED
+        char* fileName = CWvsApp::GetExceptionFileName();
+
+        ClientFileStream fs{};
+        fs.vftable = reinterpret_cast<void*>(C_FILE_STREAM_VFTABLE);
+
+        // Open(name, GENERIC_READ=0x80000000, share=128, 1, disp=0, 0, 0)
+        reinterpret_cast<FileStreamOpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, 0x80000000u, 128, 1, 0, 0, 0);
+        unsigned len = reinterpret_cast<FileStreamLenFn>(C_FILE_STREAM_GET_LENGTH)(&fs);
+
+        ZArray<char> report;
+        if (len && len < 0x2000) {
+            char* dst = report.SetSize(len);
+            reinterpret_cast<FileStreamReadFn>(C_FILE_STREAM_READ)(&fs, dst, len);
+        }
+        reinterpret_cast<FileStreamCloseFn>(C_FILE_STREAM_CLOSE)(&fs);
+
+        if (report.GetCount()) {
+            COutPacket pkt(CLIENT_START_ERROR);
+            pkt.Encode2(static_cast<unsigned short>(report.GetCount()));
+            pkt.EncodeBuffer(report.GetData(), report.GetCount());
+            CClientSocket::GetInstance()->SendPacket(&pkt);
+        }
+        // ZArray<char> report frees itself at scope exit; fs is a stack object,
+        // its handle released by Close().
+#else
+        Log("CClientSocket::OnConnect CLIENT_START_ERROR relay gated off for this version");
+#endif
+    } else {
+```
+
+> **If Task 3 found `Open` can throw on a routine missing file (OQ-throw):** guard the read path so a normal missing report never crashes — e.g. wrap the `Open`…`Close` sequence to skip when the file is absent (pre-check the path), keeping `report` empty so nothing is sent. Implement exactly what Task 3 recorded; do not add a guard the disassembly says is unnecessary.
+
+Leave everything after `} else {` (the `PLAYER_LOGGED_IN` branch, lines 214-238) unchanged. The closing `}` of the `else` and the `return 1;` stay as-is.
+
+- [ ] **Step 3: Build-verify the resolved path (v84.1)**
+
+Run:
+```bash
+scripts/wsl-build.sh GMS 84 1
+```
+Expected: exit code 0; `socket_hooks.cpp` compiles the `#if C_FILE_STREAM_RESOLVED` (true) path with no new warnings.
+
+- [ ] **Step 4: Build-verify a gated-off path (if any version is `RESOLVED 0`)**
+
+If Task 3 gated any version off, build it to prove the `#else` no-op path compiles, e.g.:
+```bash
+scripts/wsl-build.sh GMS 111 1   # or whichever version is RESOLVED 0
+```
+Expected: exit code 0. (Skip this step only if every version is `RESOLVED 1`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bypass/socket_hooks.cpp
+git commit -m "feat(socket): relay CLIENT_START_ERROR report on login connect"
+```
+
+---
+
+## Task 6: Full build matrix
+
+Prove the touched TUs compile + link across the entire acceptance matrix with no new warnings (PRD §10).
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build all five region+version combos**
+
+Run, in order, confirming each exits 0:
+```bash
+scripts/wsl-build.sh GMS 83 1
+scripts/wsl-build.sh GMS 84 1
+scripts/wsl-build.sh GMS 87 1
+scripts/wsl-build.sh GMS 111 1
+scripts/wsl-build.sh JMS 185 1
+```
+Expected: each links all edit DLLs + the proxy, exit 0, no new warnings in `bypass/socket_hooks.cpp` or `common/ZArray.h`.
+
+- [ ] **Step 2: Record the matrix result**
+
+Note in `docs/tasks/task-007-socket-connect-fidelity/memory-map.md` (or a short `build-matrix.md`) which combos are `RESOLVED 1` vs gated, so the audit phase has the record. Commit if anything was written:
+```bash
+git add -A docs/tasks/task-007-socket-connect-fidelity/
+git commit -m "docs(task-007): record build-matrix result" || true
+```
+
+---
+
+## Task 7: Runtime verification (GMS v84.1)
+
+Smoke-test the two restored behaviors against the loaded v84.1 client + atlas-login (PRD §10 acceptance, design §8). These are manual/observational checks; record outcomes.
+
+**Files:** none (runtime only)
+
+- [ ] **Step 1: Load-balancing exhaustion**
+
+Force a bad login address list (e.g. point the login address(es) at an unreachable host) and connect. Confirm the cursor advances node-by-node and, on exhaustion (`posList == NULL`), the client `Close()`s and surfaces the stock "cannot connect" failure (terminate path) rather than looping on the first address.
+
+- [ ] **Step 2: `CLIENT_START_ERROR` relay**
+
+Seed a non-empty exception report at the `CWvsApp::GetExceptionFileName()` path (length `< 0x2000`), connect to login, and observe atlas-login's `StartErrorHandleFunc` (`atlas/services/atlas-login/.../socket/handler/start_error.go`) receive a `CLIENT_START_ERROR` whose `u16 len` + bytes equal the file contents.
+
+- [ ] **Step 3: Missing-report tolerance**
+
+With no report file present, confirm login proceeds, **no** `CLIENT_START_ERROR` is sent, and there is no exception/crash (FR-11).
+
+- [ ] **Step 4: No happy-path regression**
+
+Confirm the non-login game socket still sends `PLAYER_LOGGED_IN` and the version/patch ladder still raises correctly.
+
+- [ ] **Step 5: Record results + finish the branch**
+
+Note the runtime outcomes, then use the `superpowers:finishing-a-development-branch` skill to merge/PR. Do not merge to `main` directly.
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** FR-1..FR-3 → Task 2; FR-4..FR-7 → Task 2 (exhaustion + preserved top guard, which is untouched at `socket_hooks.cpp:110-112`); FR-8..FR-12 → Task 5; FR-13 → Task 5 (`Encode2`+`EncodeBuffer`) verified at runtime in Task 7 Step 2; memory-map additions (PRD §7) → Tasks 3+4; OQ-1/OQ-throw → Task 3; OQ-2 (ZArray reuse) → Task 1; build matrix → Task 6; runtime acceptance → Task 7.
+- **Placeholder scan:** every code step shows complete code; the only intentional deferrals are the IDA-resolved addresses (Task 3) and the OQ-driven `pad` size / missing-file guard, which are disassembly facts the executor records, not invented values.
+- **Type consistency:** `SetSize`/`GetData`/`GetCount` (Task 1) match the call site in Task 5; `ClientFileStream` / `FileStream{Open,Len,Read,Close}Fn` defined in Task 5 Step 1 and used in Step 2; `C_FILE_STREAM_{RESOLVED,OPEN,GET_LENGTH,READ,CLOSE,VFTABLE}` defined in Task 4 and consumed in Task 5; `RaiseTerminate`/`RaiseDisconnect` signatures match `client_exception.h`.
+- **CMake constraint:** every new `@KEY@` is `set()` in all five `.cmake` files (real or guarded placeholder), satisfying `GenerateMemoryMap.cmake`.

--- a/docs/tasks/task-007-socket-connect-fidelity/prd.md
+++ b/docs/tasks/task-007-socket-connect-fidelity/prd.md
@@ -1,0 +1,189 @@
+# Socket Connect Fidelity — Load Balancing & CLIENT_START_ERROR — Product Requirements Document
+
+Version: v1
+Status: Draft
+Created: 2026-06-12
+---
+
+## 1. Overview
+
+The bypass edit reimplements `CClientSocket::OnConnect` so we control the login/world
+handshake and the post-connect packet sent to the server. Two behaviors of the stock
+client were left as `TODO`s in `bypass/socket_hooks.cpp` and are currently broken:
+
+1. **Connection load balancing.** When a connect attempt fails, the stock client walks
+   the candidate address list (`m_ctxConnect.lAddr`) node-by-node via the `posList`
+   cursor, retrying the *next* address each time. When the list is exhausted it `Close()`s
+   the socket and raises a typed client exception (`CTerminateException` for a login
+   socket, `CDisconnectException` otherwise) so the client surfaces the canonical
+   "cannot connect" failure dialog. Our hook instead re-passes `lAddr.GetHeadPosition()`
+   on every failure — it never advances the cursor, so it can never exhaust the list and
+   never reaches the failure path. The eventual "failed to connect to login socket"
+   logic is effectively dead.
+
+2. **`CLIENT_START_ERROR` relay.** When the connecting socket is the login socket
+   (`m_ctxConnect.bLogin`), the stock client reads the on-disk exception report
+   (path from `CWvsApp::GetExceptionFileName()`), and if non-empty sends a
+   `CLIENT_START_ERROR` (opcode `0x19` on GMS v83–v87) packet carrying the report bytes
+   so the server can log why the previous session died. Our hook grabs the filename and
+   does nothing — the packet is clobbered.
+
+This task restores both behaviors faithfully against the v84.1 disassembly, gated so the
+shared hook still compiles and behaves correctly across every configured region+version.
+
+## 2. Goals
+
+Primary goals:
+- Restore node-by-node load balancing in the `!bSuccess` path: advance `posList` via the
+  `ZList::GetNext` idiom and retry `Connect` against the current node's address.
+- On address-list exhaustion, `Close()` and raise the correct typed exception:
+  `RaiseTerminate(0x22000001)` when `bLogin`, else `RaiseDisconnect(0x21000001)`.
+- Restore `CLIENT_START_ERROR`: read the exception report file via the client's own
+  file-stream helpers, and when the report is non-empty send `COutPacket(CLIENT_START_ERROR)`
+  with `Encode2(len)` + `EncodeBuffer(bytes, len)`.
+- Keep the shared hook compiling and correct for GMS v83.1, v84.1, v87.1, v111.1, and
+  JMS v185.1 via existing `#if` gates and the per-version memory map.
+
+Non-goals:
+- No new DLL edit — this is an in-place fix to `bypass/socket_hooks.cpp`.
+- No rewrite of the handshake decoder (`decode_handshake`) or the version/patch check
+  ladder (those already raise correctly via `RaiseTerminate`/`RaisePatch`).
+- No change to the `BUILD_MAJOR_VERSION >= 95` `SendPacket` rewrite.
+- No new INI configuration surface.
+
+## 3. User Stories
+
+- As a **server operator**, I want the client to send `CLIENT_START_ERROR` after a
+  crash-restart so atlas-login's `StartErrorHandleFunc` receives the report and I can
+  diagnose client-side failures.
+- As a **player**, when the login server is unreachable I want the client to try every
+  advertised address and then show the stock "cannot connect" failure rather than hanging
+  or silently looping on the first address.
+- As a **developer**, I want the bypass `OnConnect` to match the stock client's
+  connect/failure/relay semantics so divergence bugs (infinite retry, missing server
+  telemetry) stop masking real issues.
+
+## 4. Functional Requirements
+
+### 4.1 Load-balancing advancement (`!bSuccess`, `posList != NULL`)
+- FR-1: Read the current cursor `m_ctxConnect.posList`, advance it to the next node using
+  the `ZList<ZInetAddr>::GetNext(&pos)` idiom (current node returned, cursor moved to
+  `node->m_pNext`), and write the advanced cursor back to `m_ctxConnect.posList`.
+- FR-2: Call `CClientSocket__Connect_Addr_Hook` with the **current** (pre-advance) node's
+  address — matching the stock client, which passes the saved cursor value to `Connect`.
+- FR-3: Remove the current behavior that re-passes `lAddr.GetHeadPosition()` on every
+  failure (the bug that prevents cursor advancement / list exhaustion).
+
+### 4.2 List-exhaustion failure (`!bSuccess`, `posList == NULL`)
+- FR-4: Call `pThis->Close()`.
+- FR-5: If `m_ctxConnect.bLogin` is non-zero, `RaiseTerminate(0x22000001)`
+  (stock `CTerminateException`, magic `570425345`). The call does not return.
+- FR-6: Otherwise `RaiseDisconnect(0x21000001)` (stock `CDisconnectException`, magic
+  `553648129`). The call does not return.
+- FR-7: The existing top-of-function guard `if (!m_ctxConnect.lAddr.GetCount()) return 0;`
+  is preserved unchanged.
+
+### 4.3 `CLIENT_START_ERROR` relay (`bSuccess`, `bLogin`)
+- FR-8: Obtain the report path from `CWvsApp::GetExceptionFileName()`.
+- FR-9: Read the file using the client's own file-stream object (open/get-length/read/
+  close — see `hook-design.md` §3), capping the read at the stock limit: a report is only
+  sent when `0 < length < 0x2000`.
+- FR-10: When the report buffer is present and its length is non-zero, construct
+  `COutPacket(CLIENT_START_ERROR)`, `Encode2(length)`, `EncodeBuffer(reportBytes, length)`,
+  and `CClientSocket::GetInstance()->SendPacket(&pkt)`.
+- FR-11: When the file is absent/empty or length is outside `(0, 0x2000)`, send nothing
+  (matches stock `if (buf && len)` guard). No exception is raised in this case.
+- FR-12: Release any buffer/stream resources before returning (the stock code destructs
+  the stream object and the report `ZArray`).
+
+### 4.4 Wire-format parity
+- FR-13: The emitted packet must decode cleanly against atlas-login `serverbound.StartError`:
+  `ReadUint16 length` then `ReadBytes(length)`. `Encode2` (little-endian u16) + `EncodeBuffer`
+  satisfies this.
+
+## 5. Hook / Patch Surface
+
+This task adds no new Detours hooks. It rewrites two regions **inside** the existing
+`CClientSocket__OnConnect_Hook` in `bypass/socket_hooks.cpp`. It does add calls to existing
+client routines (load-balancing uses only our own `ZList` + exception helpers; the report
+read calls into the client's file-stream helpers).
+
+Reference call site (GMS v84.1, `CClientSocket::OnConnect` @ `0x00499DCD`):
+
+| Behavior | Stock site (v84.1) | Notes |
+|---|---|---|
+| Cursor advance | `node = posList; posList = node->m_pNext; Connect(this, node)` | `posList-16+4` → `m_pNext`, `+16` → `T*` = `ZList::GetNext` |
+| Exhaustion terminate | throw `CTerminateException(0x22000001)` (`570425345`) | login socket |
+| Exhaustion disconnect | throw `CDisconnectException(0x21000001)` (`553648129`) | non-login socket |
+| Report open | `sub_49A615` (`__thiscall CFileStream::Open`, this=ecx) | wraps `CreateFileA`, handle → `[this+0x10]`, `GENERIC_READ 0x80000000` |
+| Report length | `sub_49A79E` | returns file size |
+| Report buffer resize | `sub_49BBBE` | `ZArray` set-size into report buffer |
+| Report read | `sub_49A8C9` | reads `length` bytes into buffer |
+| Report close/dtor | `sub_49A5B7` | also reachable as the stream's `Open` preamble |
+| Stream vtable | `off_B437BC` | stack object; `vtable` at `[obj+0]` |
+| Send | `COutPacket(0x19)` → `Encode2(len)` → `EncodeBuffer(buf,len)` → `SendPacket` | opcode = `CLIENT_START_ERROR` map value |
+
+Per-version addresses for the file-stream helper set + vtable + object size are tabulated
+in `memory-map.md`; v83/v87/v111/JMS values must be resolved during implementation.
+
+## 6. Configuration
+
+None. No INI keys are added or changed.
+
+## 7. Memory Map Impact
+
+New per-version `memory_maps/<REGION>/v<MAJOR>_<MINOR>.cmake` entries are required for the
+client file-stream helper set, mapped into `include/memory_map.h.in`:
+
+- `C_FILE_STREAM_OPEN` (v84.1 = `0x0049A615`)
+- `C_FILE_STREAM_GET_LENGTH` (v84.1 = `0x0049A79E`)
+- `C_FILE_STREAM_READ` (v84.1 = `0x0049A8C9`)
+- `C_FILE_STREAM_CLOSE` (v84.1 = `0x0049A5B7`)
+- `C_FILE_STREAM_VFTABLE` (v84.1 = `0x00B437BC`)
+- `C_ZARRAY_BYTE_SETSIZE` (v84.1 = `0x0049BBBE`) — report-buffer resize helper
+
+`CLIENT_START_ERROR` (`0x19` GMS v83–v87, `0x2F` v111), `C_WVS_APP_GET_EXCEPTION_FILE_NAME`,
+and the disconnect/terminate `_ThrowInfo` entries already exist. Names/exact offsets are
+finalized in `memory-map.md`. If implementation finds the stream object is impractical to
+reconstruct on some version, that version's row documents the gap (it must still compile).
+
+## 8. Non-Functional Requirements
+
+- **Stability:** the exhaustion path raises typed client exceptions that unwind into the
+  stock WinMain handler (same mechanism as `client_exception.cpp`); it must not return into
+  caller code. The report read must tolerate a missing/locked/zero-byte file without
+  crashing or raising (stock simply sends nothing).
+- **No behavioral regression** for the happy path (successful handshake → `PLAYER_LOGGED_IN`
+  for the game socket) or the version/patch check ladder.
+- **AV/Themida compatibility:** no new inline patches; we only call existing client routines
+  by mapped address, consistent with the rest of the bypass.
+- **Resource hygiene:** the report buffer and stream object must be released on every exit
+  path from the `bLogin` branch (matches stock destructor sequencing).
+
+## 9. Open Questions
+
+- OQ-1: Exact stack footprint / field layout of the client file-stream object beyond
+  `vtable@[0]` and `handle@[+0x10]` (v84.1). Resolve from disassembly during implementation;
+  size a local buffer conservatively (as `RaisePatch` does for `CPatchException`).
+- OQ-2: Whether `sub_49BBBE` is a generic `ZArray<char>::SetSize` we already model in
+  `common/ZArray.h` (preferred — reuse the template) or must be called by address.
+- OQ-3: Confirm `CLIENT_START_ERROR` opcode and the file-stream helper addresses for
+  v83.1, v87.1, v111.1, and JMS v185.1.
+
+## 10. Acceptance Criteria
+
+- [ ] `bypass/socket_hooks.cpp` `!bSuccess` path advances `posList` via `GetNext` and
+      retries the current node's address; the `GetHeadPosition()` re-pass is removed.
+- [ ] On `posList == NULL`, the hook `Close()`s then `RaiseTerminate(0x22000001)` (login)
+      or `RaiseDisconnect(0x21000001)` (non-login); neither returns.
+- [ ] The `bLogin` success branch reads the exception report and, when `0 < len < 0x2000`,
+      sends `COutPacket(CLIENT_START_ERROR)` + `Encode2(len)` + `EncodeBuffer(buf,len)`.
+- [ ] Missing/empty report → no packet, no exception.
+- [ ] Emitted packet decodes under atlas-login `serverbound.StartError` (`u16 len` + bytes).
+- [ ] New `memory_maps` entries added for every region+version; `include/memory_map.h.in`
+      updated.
+- [ ] `scripts/wsl-build.sh` compiles and links all DLLs for **GMS v83.1, v84.1, v87.1,
+      v111.1, and JMS v185.1** with no new warnings in the touched TU.
+- [ ] Runtime check on GMS v84.1 (loaded IDB): forcing a bad login address exhausts the
+      list and shows the stock failure; a seeded exception report produces a
+      `CLIENT_START_ERROR` observed by atlas-login.

--- a/include/memory_map.h.in
+++ b/include/memory_map.h.in
@@ -200,3 +200,13 @@
 #define C_TI_ZEXCEPTION @C_TI_ZEXCEPTION@
 #define C_PATCH_EXCEPTION_BUILDER @C_PATCH_EXCEPTION_BUILDER@
 #define C_COM_RAISE_ERROR_EX @C_COM_RAISE_ERROR_EX@
+
+// --- File-stream report read for CLIENT_START_ERROR (docs/tasks/task-007-socket-connect-fidelity) ---
+// C_FILE_STREAM_RESOLVED is 1 when this version's stream helpers were resolved
+// from its IDB, 0 when the relay body is gated off (placeholder addresses).
+#define C_FILE_STREAM_RESOLVED @C_FILE_STREAM_RESOLVED@
+#define C_FILE_STREAM_OPEN @C_FILE_STREAM_OPEN@
+#define C_FILE_STREAM_GET_LENGTH @C_FILE_STREAM_GET_LENGTH@
+#define C_FILE_STREAM_READ @C_FILE_STREAM_READ@
+#define C_FILE_STREAM_CLOSE @C_FILE_STREAM_CLOSE@
+#define C_FILE_STREAM_VFTABLE @C_FILE_STREAM_VFTABLE@

--- a/include/memory_map.h.in
+++ b/include/memory_map.h.in
@@ -204,7 +204,11 @@
 // --- File-stream report read for CLIENT_START_ERROR (docs/tasks/task-007-socket-connect-fidelity) ---
 // C_FILE_STREAM_RESOLVED is 1 when this version's stream helpers were resolved
 // from its IDB, 0 when the relay body is gated off (placeholder addresses).
+// C_FILE_STREAM_OPEN_INLINE is 1 for versions (e.g. GMS v95) that inline CreateFileA
+// in OnConnect instead of exposing a standalone Open(): the relay then replicates the
+// inline open and C_FILE_STREAM_OPEN is unused (0x0).
 #define C_FILE_STREAM_RESOLVED @C_FILE_STREAM_RESOLVED@
+#define C_FILE_STREAM_OPEN_INLINE @C_FILE_STREAM_OPEN_INLINE@
 #define C_FILE_STREAM_OPEN @C_FILE_STREAM_OPEN@
 #define C_FILE_STREAM_GET_LENGTH @C_FILE_STREAM_GET_LENGTH@
 #define C_FILE_STREAM_READ @C_FILE_STREAM_READ@

--- a/memory_maps/GMS/v111_1.cmake
+++ b/memory_maps/GMS/v111_1.cmake
@@ -197,6 +197,7 @@ set(C_PATCH_EXCEPTION_BUILDER  0x00564AE0) # __thiscall ctor(buffer, version): l
 set(C_COM_RAISE_ERROR_EX       0x00C91CA0) # 1-arg _com_issue_error(hr) (__stdcall) for consistency with the uniform 1-arg RaiseComErrorEx; the render path's actual 3-arg _com_issue_errorex is @0x00C91CC0 (both throw _com_error)
 
 set(C_FILE_STREAM_RESOLVED     0)          # relay gated off: redesigned stream class, no vtable __thiscall Open
+set(C_FILE_STREAM_OPEN_INLINE  0)
 set(C_FILE_STREAM_OPEN         0x0)
 set(C_FILE_STREAM_GET_LENGTH   0x0)
 set(C_FILE_STREAM_READ         0x0)

--- a/memory_maps/GMS/v111_1.cmake
+++ b/memory_maps/GMS/v111_1.cmake
@@ -195,3 +195,10 @@ set(C_TI_PATCH_EXCEPTION       0x00F30A04) # __TI3?AVCPatchException@@
 set(C_TI_ZEXCEPTION            0x00F1BB68) # __TI1?AVZException@@
 set(C_PATCH_EXCEPTION_BUILDER  0x00564AE0) # __thiscall ctor(buffer, version): lea ecx,buf; push version; call sub_564AE0 @0xc07717; CMSException::CMSException(this,0x20000000)
 set(C_COM_RAISE_ERROR_EX       0x00C91CA0) # 1-arg _com_issue_error(hr) (__stdcall) for consistency with the uniform 1-arg RaiseComErrorEx; the render path's actual 3-arg _com_issue_errorex is @0x00C91CC0 (both throw _com_error)
+
+set(C_FILE_STREAM_RESOLVED     0)          # relay gated off: redesigned stream class, no vtable __thiscall Open
+set(C_FILE_STREAM_OPEN         0x0)
+set(C_FILE_STREAM_GET_LENGTH   0x0)
+set(C_FILE_STREAM_READ         0x0)
+set(C_FILE_STREAM_CLOSE        0x0)
+set(C_FILE_STREAM_VFTABLE      0x0)

--- a/memory_maps/GMS/v83_1.cmake
+++ b/memory_maps/GMS/v83_1.cmake
@@ -195,3 +195,10 @@ set(C_TI_PATCH_EXCEPTION       0x00B52FC8) # __TI3?AVCPatchException@@
 set(C_TI_ZEXCEPTION            0x00B44EE0) # __TI1?AVZException@@
 set(C_PATCH_EXCEPTION_BUILDER  0x0051E834) # builds CPatchException obj from version (Run dispatch sub_51E834)
 set(C_COM_RAISE_ERROR_EX       0x00A5FDE4) # _com_issue_error(hr)=_com_raise_error(hr,0); v83 1-arg HRESULT raiser (render FAILED analog)
+
+set(C_FILE_STREAM_RESOLVED     0)          # relay gated off: OnConnect CFG-obfuscated, helpers unrecoverable
+set(C_FILE_STREAM_OPEN         0x0)
+set(C_FILE_STREAM_GET_LENGTH   0x0)
+set(C_FILE_STREAM_READ         0x0)
+set(C_FILE_STREAM_CLOSE        0x0)
+set(C_FILE_STREAM_VFTABLE      0x0)

--- a/memory_maps/GMS/v83_1.cmake
+++ b/memory_maps/GMS/v83_1.cmake
@@ -197,6 +197,7 @@ set(C_PATCH_EXCEPTION_BUILDER  0x0051E834) # builds CPatchException obj from ver
 set(C_COM_RAISE_ERROR_EX       0x00A5FDE4) # _com_issue_error(hr)=_com_raise_error(hr,0); v83 1-arg HRESULT raiser (render FAILED analog)
 
 set(C_FILE_STREAM_RESOLVED     0)          # relay gated off: OnConnect CFG-obfuscated, helpers unrecoverable
+set(C_FILE_STREAM_OPEN_INLINE  0)
 set(C_FILE_STREAM_OPEN         0x0)
 set(C_FILE_STREAM_GET_LENGTH   0x0)
 set(C_FILE_STREAM_READ         0x0)

--- a/memory_maps/GMS/v84_1.cmake
+++ b/memory_maps/GMS/v84_1.cmake
@@ -253,6 +253,7 @@ set(C_PATCH_EXCEPTION_BUILDER  0x00527978) # builds CPatchException obj from m_n
 set(C_COM_RAISE_ERROR_EX       0x00AABF64) # _com_raise_errorex(hr)  (Run render-fail: sub_AABF64(hr))
 
 set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN_INLINE  0)
 set(C_FILE_STREAM_OPEN         0x0049A615) # __thiscall CFileStream::Open(name,access,share,…) -> CreateFileA
 set(C_FILE_STREAM_GET_LENGTH   0x0049A79E) # __thiscall GetLength() -> size
 set(C_FILE_STREAM_READ         0x0049A8C9) # __thiscall Read(dst,len)

--- a/memory_maps/GMS/v84_1.cmake
+++ b/memory_maps/GMS/v84_1.cmake
@@ -251,3 +251,10 @@ set(C_TI_PATCH_EXCEPTION       0x00BA72F0) # __TI3?AVCPatchException@@
 set(C_TI_ZEXCEPTION            0x00B98E40) # __TI1?AVZException@@
 set(C_PATCH_EXCEPTION_BUILDER  0x00527978) # builds CPatchException obj from m_nTargetVersion (Run: v3=sub_527978(this[16]))
 set(C_COM_RAISE_ERROR_EX       0x00AABF64) # _com_raise_errorex(hr)  (Run render-fail: sub_AABF64(hr))
+
+set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN         0x0049A615) # __thiscall CFileStream::Open(name,access,share,…) -> CreateFileA
+set(C_FILE_STREAM_GET_LENGTH   0x0049A79E) # __thiscall GetLength() -> size
+set(C_FILE_STREAM_READ         0x0049A8C9) # __thiscall Read(dst,len)
+set(C_FILE_STREAM_CLOSE        0x0049A5B7) # __thiscall Close()/dtor
+set(C_FILE_STREAM_VFTABLE      0x00B437BC) # stream object vtable

--- a/memory_maps/GMS/v87_1.cmake
+++ b/memory_maps/GMS/v87_1.cmake
@@ -195,3 +195,10 @@ set(C_TI_PATCH_EXCEPTION       0x00BFC420) # __TI3?AVCPatchException@@
 set(C_TI_ZEXCEPTION            0x00BED150) # __TI1?AVZException@@
 set(C_PATCH_EXCEPTION_BUILDER  0x0054154E) # builds CPatchException obj from version (Run dispatch)
 set(C_COM_RAISE_ERROR_EX       0x00AF9E44) # _com_raise_errorex/_com_issue_error(hr)
+
+set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN         0x004A7710) # __thiscall Open -> CreateFileA
+set(C_FILE_STREAM_GET_LENGTH   0x004A7899) # __thiscall GetLength()
+set(C_FILE_STREAM_READ         0x004A79C4) # __thiscall Read(dst,len)
+set(C_FILE_STREAM_CLOSE        0x004A76B2) # __thiscall Close()/dtor
+set(C_FILE_STREAM_VFTABLE      0x00B95EA4) # stream object vtable off_B95EA4

--- a/memory_maps/GMS/v87_1.cmake
+++ b/memory_maps/GMS/v87_1.cmake
@@ -197,6 +197,7 @@ set(C_PATCH_EXCEPTION_BUILDER  0x0054154E) # builds CPatchException obj from ver
 set(C_COM_RAISE_ERROR_EX       0x00AF9E44) # _com_raise_errorex/_com_issue_error(hr)
 
 set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN_INLINE  0)
 set(C_FILE_STREAM_OPEN         0x004A7710) # __thiscall Open -> CreateFileA
 set(C_FILE_STREAM_GET_LENGTH   0x004A7899) # __thiscall GetLength()
 set(C_FILE_STREAM_READ         0x004A79C4) # __thiscall Read(dst,len)

--- a/memory_maps/GMS/v95_1.cmake
+++ b/memory_maps/GMS/v95_1.cmake
@@ -180,6 +180,17 @@ set(DR_INIT 0x004AB380) # ?DR_init@@YAXXZ. Clean v95 SetUp calls it; our reimpl 
 set(CE_TRACER_RUN 0x009BF370)
 set(SEND_HS_LOG 0x009BF6C0)
 
+# --- File-stream report read for CLIENT_START_ERROR (docs/tasks/task-007-socket-connect-fidelity) ---
+# v95 inlines CreateFileA in OnConnect (no standalone Open) — the relay replicates the
+# inline open (OPEN_INLINE=1, OPEN unused) and drives the resolved ZFileStream helpers.
+set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN_INLINE  1)          # CreateFileA inlined in OnConnect; no __thiscall Open()
+set(C_FILE_STREAM_OPEN         0x0)        # unused (inline open)
+set(C_FILE_STREAM_GET_LENGTH   0x004ACD30) # ZFileStream::GetLength
+set(C_FILE_STREAM_READ         0x004ACD60) # ZFileStream::Read(dst,len)
+set(C_FILE_STREAM_CLOSE        0x004AD7C0) # ZFileStream::Close
+set(C_FILE_STREAM_VFTABLE      0x00B49E30) # ??_7ZFileStream@@6B@
+
 set(C_MOB_C_MOB 0x0064CA30)
 
 set(C_SECURITY_CLIENT_ON_PACKET_RET_STUB 0x00000000) # JMS only

--- a/memory_maps/JMS/v185_1.cmake
+++ b/memory_maps/JMS/v185_1.cmake
@@ -1,7 +1,7 @@
 set(VERSION_HEADER 3)
 
 set(PLAYER_LOGGED_IN 0x07)
-set(CLIENT_START_ERROR 0x15)
+set(CLIENT_START_ERROR 0x0F) # audited: JMS v185 OnConnect bLogin report ctor pushes 0Fh (raw 0x004B04B4); 0x15 had no basis on either wire end (docs/tasks/task-007-socket-connect-fidelity/memory-map.md)
 
 set(GET_SE_PRIVILEGE 0x00000000) # Does not exist in JMS
 
@@ -198,3 +198,10 @@ set(C_TI_PATCH_EXCEPTION       0x00C07518) # __TI3?AVCPatchException@@
 set(C_TI_ZEXCEPTION            0x00BF7C38) # __TI1?AVZException@@
 set(C_PATCH_EXCEPTION_BUILDER  0x0055127C) # __thiscall ctor(buffer,version)->buffer; writes *buf=0x20000000
 set(C_COM_RAISE_ERROR_EX       0x00B4D510) # ?_com_issue_error@@YGXJ@Z (1-arg HRESULT raiser)
+
+set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN         0x004B0864) # __thiscall Open -> CreateFileA
+set(C_FILE_STREAM_GET_LENGTH   0x004B09ED) # __thiscall GetLength()
+set(C_FILE_STREAM_READ         0x004B0B18) # __thiscall Read(dst,len)
+set(C_FILE_STREAM_CLOSE        0x004B0806) # __thiscall Close()/dtor
+set(C_FILE_STREAM_VFTABLE      0x00BE4CAC) # stream object vtable off_BE4CAC

--- a/memory_maps/JMS/v185_1.cmake
+++ b/memory_maps/JMS/v185_1.cmake
@@ -200,6 +200,7 @@ set(C_PATCH_EXCEPTION_BUILDER  0x0055127C) # __thiscall ctor(buffer,version)->bu
 set(C_COM_RAISE_ERROR_EX       0x00B4D510) # ?_com_issue_error@@YGXJ@Z (1-arg HRESULT raiser)
 
 set(C_FILE_STREAM_RESOLVED     1)
+set(C_FILE_STREAM_OPEN_INLINE  0)
 set(C_FILE_STREAM_OPEN         0x004B0864) # __thiscall Open -> CreateFileA
 set(C_FILE_STREAM_GET_LENGTH   0x004B09ED) # __thiscall GetLength()
 set(C_FILE_STREAM_READ         0x004B0B18) # __thiscall Read(dst,len)


### PR DESCRIPTION
## Summary

Restores two stock-client behaviors inside `CClientSocket__OnConnect_Hook` (`bypass/socket_hooks.cpp`), gated across GMS v83.1/v84.1/v87.1/v111.1 + JMS v185.1:

- **Connect load-balancing** (`!bSuccess`) — advances the `m_ctxConnect.posList` cursor node-by-node via `ZList<ZInetAddr>::GetNext` and retries each address; on exhaustion `Close()`s and raises the stock typed exception (`RaiseTerminate(0x22000001)` login / `RaiseDisconnect(0x21000001)` game), both `[[noreturn]]`. Unconditional; no new map symbols.
- **`CLIENT_START_ERROR` relay** (`bSuccess && bLogin`) — reconstructs the stock `CFileStream` stack object, drives `Open/GetLength/Read/Close` by mapped address into a `ZArray<char>`, and emits `COutPacket(CLIENT_START_ERROR)` + `Encode2(len)` + `EncodeBuffer(buf,len)` (matches atlas-login `StartError.Decode`).

### Supporting changes
- `common/ZArray.h` — additive `SetSize(size_t)`/`GetData()` modeling the stock report-buffer resize (`sub_49BBBE`).
- `include/memory_map.h.in` + 5 `.cmake` files — new `C_FILE_STREAM_{OPEN,GET_LENGTH,READ,CLOSE,VFTABLE}` set + a `C_FILE_STREAM_RESOLVED` per-version guard. Relay body wrapped in `#if C_FILE_STREAM_RESOLVED … #else Log-only no-op #endif`.

### Notable findings (IDA-audited, see `docs/tasks/task-007-socket-connect-fidelity/memory-map.md`)
- **JMS v185 opcode corrected `0x15 → 0x0F`** — the client's bLogin report `COutPacket` ctor pushes `0x0F` (raw `0x004B04B4`); `0x15` had no basis on either wire end. *(Server-side: atlas-login's JMS v185 template registers no StartError handler — a separate atlas-ms gap, out of scope.)*
- **Missing-file guard (OQ-throw):** the stock `Open` throws `ZException` on `INVALID_HANDLE_VALUE` and the throw escapes `OnConnect`, so the relay pre-checks existence with `GetFileAttributesA` — a routine missing report is a silent no-op (no packet, no crash).
- **Object size (OQ-1):** highest stock write is `[+0x34]` dword → `ClientFileStream` sized `0x40` (`pad[0x3C]`).
- **Gated off:** GMS v83.1 (OnConnect CFG-obfuscated) and v111.1 (redesigned non-vtable stream class) use `0x0` placeholders + `C_FILE_STREAM_RESOLVED 0`; relay compiles a Log-only no-op there.

### Reviews
Each code task passed two-stage subagent review (spec compliance + code quality); Task 3's addresses were independently re-derived from the IDBs and the relay's `__thiscall` ABI confirmed against `Open`'s `retn 1Ch` (8-param) signature.

## Build matrix (WSL clang-cl + xwin cross-compile)
All 5 region/version combos `scripts/wsl-build.sh` → **exit 0**, no new warnings in `socket_hooks.cpp`/`ZArray.h`:

| GMS 83 1 | GMS 84 1 | GMS 87 1 | GMS 111 1 | JMS 185 1 |
|---|---|---|---|---|
| ✅ gated | ✅ resolved | ✅ resolved | ✅ gated | ✅ resolved |

> Note: WSL build is the cross-compile *check*; Windows CI owns the authoritative build.

## Test Plan — runtime verification (Task 7, GMS v84.1, **pending**)
Manual checks against the live client + atlas-login:
- [ ] **Load-balancing exhaustion:** point login address(es) at an unreachable host → cursor advances node-by-node; on `posList==NULL` the client `Close()`s and surfaces the stock terminate (no looping on the first address).
- [ ] **Relay:** seed a non-empty report (`< 0x2000`) at `CWvsApp::GetExceptionFileName()` path → atlas-login `StartErrorHandleFunc` receives `CLIENT_START_ERROR` whose `u16 len` + bytes equal the file.
- [ ] **Missing-report tolerance:** no report file → login proceeds, no packet sent, no exception/crash.
- [ ] **No happy-path regression:** non-login game socket still sends `PLAYER_LOGGED_IN`; version/patch ladder still raises correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)