### PR TITLE
fix: correct CFileStream::Open arg order in CLIENT_START_ERROR relay

### DIFF
--- a/bypass/socket_hooks.cpp
+++ b/bypass/socket_hooks.cpp
@@ -33,8 +33,15 @@ struct ClientFileStream {
     char pad[0x3C]; // [+0x04] conservative; covers the [+0x34] flag write
 };
 
-using FileStreamOpenFn = int(__thiscall*)(void* self, const char* name, unsigned access, unsigned share, int a3,
-                                          unsigned disp, int a5, int a6);
+// CFileStream::Open's positional args map onto the CreateFileA call inside it
+// (verified from the v84.1 0x49A615 disasm): the 2nd..7th stack args become, in
+// order, dwCreationDisposition, dwFlagsAndAttributes, dwShareMode, dwDesiredAccess,
+// lpSecurityAttributes, hTemplateFile -- NOT the access/share-first order CreateFileA
+// itself takes. Passing them in CreateFileA order puts GENERIC_READ into the
+// disposition slot, which CreateFileA rejects with ERROR_INVALID_PARAMETER (87).
+using FileStreamOpenFn = int(__thiscall*)(void* self, const char* name, unsigned disposition,
+                                          unsigned flagsAndAttributes, unsigned shareMode, unsigned desiredAccess,
+                                          void* securityAttributes, void* templateFile);
 using FileStreamLenFn = unsigned(__thiscall*)(void* self);
 using FileStreamReadFn = int(__thiscall*)(void* self, void* dst, unsigned len);
 using FileStreamCloseFn = void(__thiscall*)(void* self);
@@ -255,8 +262,10 @@ INT __fastcall CClientSocket__OnConnect_Hook(CClientSocket* pThis, PVOID edx, in
                 fileName, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
             *reinterpret_cast<unsigned*>(reinterpret_cast<char*>(&fs) + 0x34) |= 1u;
 #else
-            // Open(name, GENERIC_READ=0x80000000, share=128, 1, disp=0, 0, 0)
-            reinterpret_cast<FileStreamOpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, 0x80000000u, 128, 1, 0, 0, 0);
+            // Open the existing report read-only, matching the inline CreateFileA above.
+            // Arg order is disposition/flags/share/access per the FileStreamOpenFn note.
+            reinterpret_cast<FileStreamOpenFn>(C_FILE_STREAM_OPEN)(&fs, fileName, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                                                                   FILE_SHARE_READ, GENERIC_READ, nullptr, nullptr);
 #endif
             unsigned len = reinterpret_cast<FileStreamLenFn>(C_FILE_STREAM_GET_LENGTH)(&fs);
 


### PR DESCRIPTION
## Summary

Fixes a login-time crash dialog **"error code: 87 (the parameter is incorrect)"** caused by our `CLIENT_START_ERROR` relay calling the stock `CFileStream::Open` with **scrambled arguments**.

The relay in `CClientSocket::OnConnect` (login branch) called `Open` by address using `CreateFileA`'s own argument order (`name, access, share, …`). But `Open`'s real positional signature maps its 2nd–7th args onto `CreateFileA` as **disposition, flags, share, access, security, template** — verified from the v84.1 `0x49A615` disassembly:

```asm
push arg_18      ; hTemplateFile
push arg_8       ; dwFlagsAndAttributes
push arg_4       ; dwCreationDisposition  ←
push arg_14      ; lpSecurityAttributes
push arg_C       ; dwShareMode
push arg_10      ; dwDesiredAccess
push arg_0       ; lpFileName
call CreateFileA
```

So `GENERIC_READ` (`0x80000000`) landed in the **`dwCreationDisposition`** slot. That's out of the valid 1–5 range → `CreateFileA` fails with `ERROR_INVALID_PARAMETER` (87) → `Open` reads `GetLastError()` and throws a `ZException` carrying 87 → unwinds to `WinMain` and surfaces the dialog. The connect runs synchronously inside `CWvsApp::SetUp`, so it presents at login. Latent because it only fires when an exception-report file already exists on disk.

## Fix

Reorder the call to match the inline `CreateFileA` path directly above it:

```cpp
Open(&fs, fileName, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GENERIC_READ, nullptr, nullptr);
```

Also renamed the `FileStreamOpenFn` typedef params to their true positional meaning with an explanatory note.

## Diagnosis trail

- `_com_error::ErrorMessage()` / `FormatMessageA(87)` confirmed the displayed code = `ERROR_INVALID_PARAMETER`.
- `RaiseException` (`0xE06D7363`) breakpoint stack pointed at `CClientSocket__OnConnect_Hook` → `CFileStream::Open` (`0x49A615`).
- `dword_C49AA4` (called pre-throw) is `GetLastError` (WinMain compares its result to `183`).

## Version coverage

The call site is version-agnostic shared code. Disassembled `CFileStream::Open` in every IDB; the standalone path is **byte-for-byte identical** where it compiles:

| Version | Relay (`RESOLVED`) | Open path | Addr | Status |
|---|---|---|---|---|
| GMS 83 | 0 — gated off | — | — | not affected |
| GMS 84 | 1 | standalone | `0x49A615` | fixed (reference) |
| GMS 87 | 1 | standalone | `0x4A7710` | fixed (identical) |
| GMS 95 | 1 | **inline** | — | already correct |
| GMS 111 | 0 — gated off | — | — | not affected |
| JMS 185 | 1 | standalone | `0x4B0864` | fixed (identical) |

## Testing

- WSL cross-compile (`scripts/wsl-build.sh GMS 84 1`): `bypass-1.0.0.dll` links cleanly (`>> OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)